### PR TITLE
Add follow-up confirmation flow to delete profile command

### DIFF
--- a/commands/deleteProfile.ts
+++ b/commands/deleteProfile.ts
@@ -1,10 +1,62 @@
 import User from "../models/User.ts";
 import { ISession } from "../types.ts";
-import {
-  extractTelegramSession,
-  TelegramSession
-} from "../entities/TelegramSession.ts";
-import TelegramBot from "node-telegram-bot-api";
+import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+
+const DELETE_PROFILE_CONFIRMATION_PROMPT =
+  "*Vous êtes sur le point de supprimer votre profil JOÉL*, comprenant l'ensemble de vos contacts, fonctions et organisations suivis.\n" +
+  "⚠️ *Attention, ces données ne sont pas récupérables par la suite* ⚠️\n" +
+  'Pour confirmer vous devez répondre "SUPPRIMER MON COMPTE" en majuscule à ce message';
+
+async function askDeleteProfileQuestion(session: ISession): Promise<void> {
+  await askFollowUpQuestion(
+    session,
+    DELETE_PROFILE_CONFIRMATION_PROMPT,
+    handleDeleteProfileAnswer,
+    {
+      keyboard: session.messageApp === "WhatsApp" ? undefined : []
+    }
+  );
+}
+
+async function handleDeleteProfileAnswer(
+  session: ISession,
+  answer: string
+): Promise<boolean> {
+  const trimmedAnswer = answer.trim();
+
+  if (trimmedAnswer.length === 0) {
+    await session.sendMessage(
+      "Votre réponse n'a pas été reconnue. 👎\nSuppression annulée."
+    );
+    return true;
+  }
+
+  if (trimmedAnswer.startsWith("/")) {
+    return false;
+  }
+
+  if (session.user == null) {
+    await session.sendMessage(
+      `Aucun profil utilisateur n'est actuellement associé à votre identifiant ${session.chatId}`
+    );
+    return true;
+  }
+
+  if (trimmedAnswer === "SUPPRIMER MON COMPTE") {
+    await User.deleteOne({
+      _id: session.user._id
+    });
+    session.user = null;
+    await session.sendMessage(
+      `🗑 Votre profil a bien été supprimé ! 👋\nUn profil vierge sera créé lors de l'ajout du prochain suivi ⚠️`
+    );
+    await session.log({ event: "/user-deletion-self" });
+  } else {
+    await session.sendMessage("Suppression annulée.");
+  }
+
+  return true;
+}
 
 export const deleteProfileCommand = async (
   session: ISession
@@ -18,46 +70,7 @@ export const deleteProfileCommand = async (
       return;
     }
 
-    const tgSession: TelegramSession | undefined = await extractTelegramSession(
-      session,
-      true
-    );
-    if (tgSession == null) return;
-
-    const tgBot = tgSession.telegramBot;
-
-    const question = await tgBot.sendMessage(
-      tgSession.chatIdTg,
-      `*Vous êtes sur le point de supprimer votre profil JOÉL*, comprenant l'ensemble de vos contacts, fonctions et organisations suivis.\n
-⚠️ *Attention, ces données ne sont pas récupérables par la suite* ⚠️
-Pour confirmer vous devez répondre "SUPPRIMER MON COMPTE" en majuscule à ce message`,
-      {
-        parse_mode: "Markdown",
-        reply_markup: {
-          force_reply: true
-        }
-      }
-    );
-    tgBot.onReplyToMessage(
-      tgSession.chatIdTg,
-      question.message_id,
-      (tgMsg: TelegramBot.Message) => {
-        void (async () => {
-          if (session.user == null) return;
-          if (tgMsg.text === "SUPPRIMER MON COMPTE") {
-            await User.deleteOne({
-              _id: session.user._id
-            });
-            await session.sendMessage(
-              `🗑 Votre profil a bien été supprimé ! 👋\nUn profil vierge sera créé lors de l'ajout du prochain suivi ⚠️`
-            );
-            await session.log({ event: "/user-deletion-self" });
-          } else {
-            await session.sendMessage("Suppression annulée.");
-          }
-        })();
-      }
-    );
+    await askDeleteProfileQuestion(session);
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
## Summary
- replace the Telegram-only confirmation with the shared follow-up manager
- ensure invalid answers are handled and the session is cleared when deletion succeeds

## Testing
- npm test *(fails: jest not found before dependencies are installed)*
- npm install *(fails: signal-cli download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ce912ffaf4832dbfa60c4fb73ed058