### PR TITLE
Add last message tracking and broadcast utility

### DIFF
--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -70,8 +70,8 @@ export async function recordSuccessfulDelivery(
   chatId: number
 ): Promise<void> {
   await User.updateOne(
-    { messageApp, chatId, status: { $ne: "blocked" } },
-    { $set: { lastMessageReceivedAt: new Date() } }
+    { messageApp, chatId, status: { $ne: "deactivated" } },
+    { $set: { lastMessageReceivedAt: new Date(), status: "active" } }
   );
 }
 

--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -65,6 +65,16 @@ export async function migrateUser(rawUser: IRawUser): Promise<void> {
   return;
 }
 
+export async function recordSuccessfulDelivery(
+  messageApp: MessageApp,
+  chatId: number
+): Promise<void> {
+  await User.updateOne(
+    { messageApp, chatId, status: { $ne: "blocked" } },
+    { $set: { lastMessageReceivedAt: new Date() } }
+  );
+}
+
 export async function sendMessage(
   messageApp: MessageApp,
   chatId: number,

--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -70,7 +70,7 @@ export async function recordSuccessfulDelivery(
   chatId: number
 ): Promise<void> {
   await User.updateOne(
-    { messageApp, chatId, status: { $ne: "deactivated" } },
+    { messageApp, chatId },
     { $set: { lastMessageReceivedAt: new Date(), status: "active" } }
   );
 }

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -85,7 +85,7 @@ export async function sendSignalAppMessage(
 ): Promise<boolean> {
   try {
     const cleanMessage = markdown2plainText(message);
-    const userPhoneIdInt = "+" + userPhoneId;
+    const userPhoneIdInt = "+" + userPhoneId.toString();
     const mArr = splitText(cleanMessage, SIGNAL_MESSAGE_CHAR_LIMIT);
     for (const elem of mArr) {
       await signalCli.sendMessage(userPhoneIdInt, elem);

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -1,6 +1,6 @@
 import { ISession, IUser, MessageApp } from "../types.ts";
 import User from "../models/User.ts";
-import { loadUser } from "./Session.ts";
+import { loadUser, recordSuccessfulDelivery } from "./Session.ts";
 import umami from "../utils/umami.ts";
 import { markdown2plainText, splitText } from "../utils/text.utils.ts";
 import { SignalCli } from "signal-sdk";
@@ -97,6 +97,7 @@ export async function sendSignalAppMessage(
         setTimeout(resolve, SIGNAL_COOL_DOWN_DELAY_SECONDS * 1000)
       );
     }
+    await recordSuccessfulDelivery(SignalMessageApp, userPhoneId);
   } catch (error) {
     console.log(error);
     return false;

--- a/entities/TelegramSession.ts
+++ b/entities/TelegramSession.ts
@@ -1,7 +1,7 @@
 import { ISession, IUser, MessageApp } from "../types.ts";
 import { Telegram } from "telegraf";
 import User from "../models/User.ts";
-import { loadUser } from "./Session.ts";
+import { loadUser, recordSuccessfulDelivery } from "./Session.ts";
 import umami from "../utils/umami.ts";
 import { splitText } from "../utils/text.utils.ts";
 import { ErrorMessages } from "./ErrorMessages.ts";
@@ -111,6 +111,8 @@ export class TelegramSession implements ISession {
         setTimeout(resolve, TELEGRAM_COOL_DOWN_DELAY_SECONDS * 1000)
       );
     }
+
+    await recordSuccessfulDelivery(this.messageApp, this.chatId);
   }
 }
 
@@ -233,5 +235,6 @@ export async function sendTelegramMessage(
     return false;
   }
 
+  await recordSuccessfulDelivery("Telegram", chatId);
   return true;
 }

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -1,6 +1,6 @@
 import { ISession, IUser, MessageApp } from "../types.ts";
 import User from "../models/User.ts";
-import { loadUser } from "./Session.ts";
+import { loadUser, recordSuccessfulDelivery } from "./Session.ts";
 import umami from "../utils/umami.ts";
 import { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 import { ServerMessageResponse } from "whatsapp-api-js/types";
@@ -277,6 +277,7 @@ export async function sendWhatsAppMessage(
     console.log(error);
     return false;
   }
+  await recordSuccessfulDelivery(WhatsAppMessageApp, userPhoneId);
   return true;
 }
 

--- a/models/User.ts
+++ b/models/User.ts
@@ -103,6 +103,9 @@ const UserSchema = new Schema<IUser, UserModel>(
     },
     lastInteractionMonth: {
       type: Date
+    },
+    lastMessageReceivedAt: {
+      type: Date
     }
   },
   {

--- a/scripts/broadcastMessage.ts
+++ b/scripts/broadcastMessage.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { mongodbConnect } from "../db.ts";
 import User from "../models/User.ts";
-import { MessageApp } from "../types.d.ts";
+import { MessageApp } from "../types.ts";
 import { ExternalMessageOptions, sendMessage } from "../entities/Session.ts";
 import {
   parseEnabledMessageApps,
@@ -60,11 +60,11 @@ export async function broadcastMessage(
     if (success) {
       succeeded += 1;
       options?.logger?.(
-        `Message delivered to ${recipient.messageApp} user ${recipient.chatId}`
+        `Message delivered to ${recipient.messageApp} user ${String(recipient.chatId)}`
       );
     } else {
       options?.logger?.(
-        `Failed to deliver message to ${recipient.messageApp} user ${recipient.chatId}`
+        `Failed to deliver message to ${recipient.messageApp} user ${String(recipient.chatId)}`
       );
     }
   }
@@ -76,14 +76,9 @@ export async function broadcastMessage(
   };
 }
 
-if (import.meta.main) {
-  const [, , ...args] = process.argv;
-  if (args.length === 0) {
-    console.error("Usage: ts-node utils/broadcastMessage.ts <message>");
-    process.exit(1);
-  }
-
-  const message = args.join(" ");
+await (async () => {
+  const message = "test message";
+  //const message = args.join(" ");
 
   try {
     await mongodbConnect();
@@ -91,11 +86,11 @@ if (import.meta.main) {
       logger: console.log
     });
     console.log(
-      `Broadcast completed: ${result.succeeded}/${result.attempted} deliveries succeeded.`
+      `Broadcast completed: ${String(result.succeeded)}/${String(result.attempted)} deliveries succeeded.`
     );
     process.exit(result.failed === 0 ? 0 : 2);
   } catch (error) {
     console.error("Broadcast failed:", error);
     process.exit(1);
   }
-}
+})();

--- a/scripts/broadcastMessage.ts
+++ b/scripts/broadcastMessage.ts
@@ -1,12 +1,12 @@
 import "dotenv/config";
 import { mongodbConnect } from "../db.ts";
 import User from "../models/User.ts";
-import { MessageApp } from "../types.ts";
+import { MessageApp } from "../types.d.ts";
 import { ExternalMessageOptions, sendMessage } from "../entities/Session.ts";
 import {
   parseEnabledMessageApps,
   resolveExternalMessageOptions
-} from "./messageAppOptions.ts";
+} from "../utils/messageAppOptions.ts";
 
 export interface BroadcastMessageOptions {
   includeBlockedUsers?: boolean;

--- a/scripts/broadcastMessage.ts
+++ b/scripts/broadcastMessage.ts
@@ -7,6 +7,7 @@ import {
   parseEnabledMessageApps,
   resolveExternalMessageOptions
 } from "../utils/messageAppOptions.ts";
+import umami from "../utils/umami.ts";
 
 export interface BroadcastMessageOptions {
   includeBlockedUsers?: boolean;
@@ -88,6 +89,7 @@ await (async () => {
     console.log(
       `Broadcast completed: ${String(result.succeeded)}/${String(result.attempted)} deliveries succeeded.`
     );
+    await umami.log({ event: "/message-sent-broadcast" });
     process.exit(result.failed === 0 ? 0 : 2);
   } catch (error) {
     console.error("Broadcast failed:", error);

--- a/types.d.ts
+++ b/types.d.ts
@@ -55,6 +55,8 @@ export interface IUser {
     lastUpdate: Date;
   }[];
 
+  lastMessageReceivedAt?: Date;
+
   lastInteractionDay?: Date;
   lastInteractionWeek?: Date;
   lastInteractionMonth?: Date;

--- a/utils/broadcastMessage.ts
+++ b/utils/broadcastMessage.ts
@@ -1,0 +1,170 @@
+import "dotenv/config";
+import { mongodbConnect } from "../db.ts";
+import { ExternalMessageOptions, sendMessage } from "../entities/Session.ts";
+import { WHATSAPP_API_VERSION } from "../entities/WhatsAppSession.ts";
+import { ErrorMessages } from "../entities/ErrorMessages.ts";
+import User from "../models/User.ts";
+import { MessageApp } from "../types.ts";
+import { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+import { SignalCli } from "signal-sdk";
+
+const SUPPORTED_MESSAGE_APPS: readonly MessageApp[] = [
+  "Telegram",
+  "WhatsApp",
+  "Signal"
+];
+
+export interface BroadcastMessageOptions {
+  includeBlockedUsers?: boolean;
+  enabledAppsOverride?: MessageApp[];
+  logger?: (message: string) => void;
+  externalMessageOptions?: ExternalMessageOptions;
+}
+
+export interface BroadcastMessageResult {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+}
+
+function parseEnabledMessageApps(): MessageApp[] {
+  const { ENABLED_APPS } = process.env;
+  if (ENABLED_APPS === undefined) {
+    throw new Error("ENABLED_APPS env var not set");
+  }
+
+  const parsed = JSON.parse(ENABLED_APPS) as MessageApp[];
+  const supportedApps = parsed.filter((app) =>
+    SUPPORTED_MESSAGE_APPS.includes(app)
+  );
+
+  const unsupportedApps = parsed.filter(
+    (app) => !SUPPORTED_MESSAGE_APPS.includes(app)
+  );
+
+  if (unsupportedApps.length > 0) {
+    console.warn(
+      `Ignoring unsupported apps for broadcast: ${unsupportedApps.join(", ")}`
+    );
+  }
+
+  return supportedApps;
+}
+
+async function ensureExternalMessageOptions(
+  enabledApps: MessageApp[],
+  provided?: ExternalMessageOptions
+): Promise<ExternalMessageOptions> {
+  const resolved: ExternalMessageOptions = { ...(provided ?? {}) };
+
+  if (enabledApps.includes("WhatsApp") && resolved.whatsAppAPI == null) {
+    const { WHATSAPP_USER_TOKEN, WHATSAPP_APP_SECRET, WHATSAPP_VERIFY_TOKEN } =
+      process.env;
+    if (
+      WHATSAPP_USER_TOKEN === undefined ||
+      WHATSAPP_APP_SECRET === undefined ||
+      WHATSAPP_VERIFY_TOKEN === undefined
+    ) {
+      throw new Error(ErrorMessages.WHATSAPP_ENV_NOT_SET);
+    }
+
+    resolved.whatsAppAPI = new WhatsAppAPI({
+      token: WHATSAPP_USER_TOKEN,
+      appSecret: WHATSAPP_APP_SECRET,
+      webhookVerifyToken: WHATSAPP_VERIFY_TOKEN,
+      v: WHATSAPP_API_VERSION
+    });
+  }
+
+  if (enabledApps.includes("Signal") && resolved.signalCli == null) {
+    const { SIGNAL_BAT_PATH, SIGNAL_PHONE_NUMBER } = process.env;
+    if (SIGNAL_BAT_PATH === undefined || SIGNAL_PHONE_NUMBER === undefined) {
+      throw new Error(ErrorMessages.SIGNAL_ENV_NOT_SET);
+    }
+
+    const signalCli = new SignalCli(SIGNAL_BAT_PATH, SIGNAL_PHONE_NUMBER);
+    await signalCli.connect();
+    resolved.signalCli = signalCli;
+  }
+
+  return resolved;
+}
+
+export async function broadcastMessage(
+  message: string,
+  options?: BroadcastMessageOptions
+): Promise<BroadcastMessageResult> {
+  if (message.trim().length === 0) {
+    throw new Error("Broadcast message cannot be empty");
+  }
+
+  const enabledApps = options?.enabledAppsOverride ?? parseEnabledMessageApps();
+  if (enabledApps.length === 0) {
+    return { attempted: 0, succeeded: 0, failed: 0 };
+  }
+
+  const deliveryOptions = await ensureExternalMessageOptions(
+    enabledApps,
+    options?.externalMessageOptions
+  );
+
+  const recipients = await User.find(
+    {
+      messageApp: { $in: enabledApps },
+      ...(options?.includeBlockedUsers ? {} : { status: "active" })
+    },
+    { _id: 0, chatId: 1, messageApp: 1 }
+  ).lean();
+
+  let succeeded = 0;
+
+  for (const recipient of recipients) {
+    const success = await sendMessage(
+      recipient.messageApp,
+      recipient.chatId,
+      message,
+      deliveryOptions
+    );
+
+    if (success) {
+      succeeded += 1;
+      options?.logger?.(
+        `Message delivered to ${recipient.messageApp} user ${recipient.chatId}`
+      );
+    } else {
+      options?.logger?.(
+        `Failed to deliver message to ${recipient.messageApp} user ${recipient.chatId}`
+      );
+    }
+  }
+
+  return {
+    attempted: recipients.length,
+    succeeded,
+    failed: recipients.length - succeeded
+  };
+}
+
+if (import.meta.main) {
+  const [, , ...args] = process.argv;
+  if (args.length === 0) {
+    console.error("Usage: ts-node utils/broadcastMessage.ts <message>");
+    process.exit(1);
+  }
+
+  const message = args.join(" ");
+
+  try {
+    await mongodbConnect();
+    const result = await broadcastMessage(message, {
+      logger: console.log
+    });
+    console.log(
+      `Broadcast completed: ${result.succeeded}/${result.attempted} deliveries succeeded.`
+    );
+    process.exit(result.failed === 0 ? 0 : 2);
+  } catch (error) {
+    console.error("Broadcast failed:", error);
+    process.exit(1);
+  }
+}

--- a/utils/messageAppOptions.ts
+++ b/utils/messageAppOptions.ts
@@ -29,9 +29,7 @@ export function parseEnabledMessageApps(
   );
 
   if (unsupportedApps.length > 0) {
-    console.warn(
-      `Ignoring unsupported apps: ${unsupportedApps.join(", ")}`
-    );
+    console.warn(`Ignoring unsupported apps: ${unsupportedApps.join(", ")}`);
   }
 
   return supportedApps;

--- a/utils/messageAppOptions.ts
+++ b/utils/messageAppOptions.ts
@@ -1,0 +1,77 @@
+import { ExternalMessageOptions } from "../entities/Session.ts";
+import { ErrorMessages } from "../entities/ErrorMessages.ts";
+import { WHATSAPP_API_VERSION } from "../entities/WhatsAppSession.ts";
+import { MessageApp } from "../types.ts";
+import { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+import { SignalCli } from "signal-sdk";
+
+export const SUPPORTED_MESSAGE_APPS: readonly MessageApp[] = [
+  "Telegram",
+  "WhatsApp",
+  "Signal",
+  "Matrix"
+] as const;
+
+export function parseEnabledMessageApps(
+  enabledAppsEnv: string | undefined = process.env.ENABLED_APPS
+): MessageApp[] {
+  if (enabledAppsEnv === undefined) {
+    throw new Error("ENABLED_APPS env var not set");
+  }
+
+  const parsed = JSON.parse(enabledAppsEnv) as MessageApp[];
+  const supportedApps = parsed.filter((app) =>
+    SUPPORTED_MESSAGE_APPS.includes(app)
+  );
+
+  const unsupportedApps = parsed.filter(
+    (app) => !SUPPORTED_MESSAGE_APPS.includes(app)
+  );
+
+  if (unsupportedApps.length > 0) {
+    console.warn(
+      `Ignoring unsupported apps: ${unsupportedApps.join(", ")}`
+    );
+  }
+
+  return supportedApps;
+}
+
+export async function resolveExternalMessageOptions(
+  enabledApps: MessageApp[],
+  provided?: ExternalMessageOptions
+): Promise<ExternalMessageOptions> {
+  const resolved: ExternalMessageOptions = { ...(provided ?? {}) };
+
+  if (enabledApps.includes("WhatsApp") && resolved.whatsAppAPI == null) {
+    const { WHATSAPP_USER_TOKEN, WHATSAPP_APP_SECRET, WHATSAPP_VERIFY_TOKEN } =
+      process.env;
+    if (
+      WHATSAPP_USER_TOKEN === undefined ||
+      WHATSAPP_APP_SECRET === undefined ||
+      WHATSAPP_VERIFY_TOKEN === undefined
+    ) {
+      throw new Error(ErrorMessages.WHATSAPP_ENV_NOT_SET);
+    }
+
+    resolved.whatsAppAPI = new WhatsAppAPI({
+      token: WHATSAPP_USER_TOKEN,
+      appSecret: WHATSAPP_APP_SECRET,
+      webhookVerifyToken: WHATSAPP_VERIFY_TOKEN,
+      v: WHATSAPP_API_VERSION
+    });
+  }
+
+  if (enabledApps.includes("Signal") && resolved.signalCli == null) {
+    const { SIGNAL_BAT_PATH, SIGNAL_PHONE_NUMBER } = process.env;
+    if (SIGNAL_BAT_PATH === undefined || SIGNAL_PHONE_NUMBER === undefined) {
+      throw new Error(ErrorMessages.SIGNAL_ENV_NOT_SET);
+    }
+
+    const signalCli = new SignalCli(SIGNAL_BAT_PATH, SIGNAL_PHONE_NUMBER);
+    await signalCli.connect();
+    resolved.signalCli = signalCli;
+  }
+
+  return resolved;
+}

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -43,6 +43,7 @@ export type UmamiEvent =
   | "/message-sent-signal"
   | "/message-sent-telegram"
   | "/message-sent-whatsapp"
+  | "/message-sent-broadcast"
   | "/matrix-too-many-requests"
   | "/matrix-too-many-requests-aborted"
   | "/telegram-too-many-requests"


### PR DESCRIPTION
## Summary
- add an optional `lastMessageReceivedAt` field to the user schema and type definition
- record the last successful message delivery across Telegram, WhatsApp and Signal
- introduce a utility script to broadcast a message across all enabled messaging apps

## Testing
- npm test *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d56e001c24832dad39e8f00a6fdc96