### PR TITLE
feat: add modular meta follow preferences

### DIFF
--- a/entities/JORFSearchMetaItem.ts
+++ b/entities/JORFSearchMetaItem.ts
@@ -1,0 +1,39 @@
+export type JORFSearchMetaModule =
+  | "publication"
+  | "publication-tag"
+  | "publication-ministere"
+  | "publication-autorite"
+  | "publication-nor"
+  | "custom";
+
+export type JORFSearchMetaGranularity =
+  | "module"
+  | "collection"
+  | "item"
+  | "filter";
+
+export interface JORFSearchMetaFilter {
+  key: string;
+  value: string | boolean;
+}
+
+/**
+ * Representation of a followable metadata entity exposed by JORFSearch.
+ * It abstracts how the metadata item was produced and focuses on
+ * the module it belongs to and the granularity at which it can be followed.
+ */
+export interface JORFSearchMetaItem {
+  module: JORFSearchMetaModule;
+  granularity: JORFSearchMetaGranularity;
+  identifier?: string;
+  label?: string;
+  filters?: JORFSearchMetaFilter[];
+}
+
+export interface UserMetaFollowPreference {
+  module: JORFSearchMetaModule;
+  granularity: JORFSearchMetaGranularity;
+  identifier?: string;
+  label?: string;
+  filters?: JORFSearchMetaFilter[];
+}

--- a/tests/02.user.test.ts
+++ b/tests/02.user.test.ts
@@ -27,6 +27,20 @@ const exampleFollowedOrganisations: IUser["followedOrganisations"] = [
   { wikidataId: "987654321", lastUpdate: new Date() }
 ];
 
+const exampleFollowedMeta: IUser["followedMeta"] = [
+  {
+    module: "publication",
+    granularity: "item",
+    identifier: "JORF123456789",
+    label: "JORF Publication JORF123456789",
+    filters: [
+      { key: "ministere", value: "Ministère de l'Intérieur" },
+      { key: "mesure_nominative", value: true }
+    ],
+    lastUpdate: new Date()
+  }
+];
+
 const MockTelegramSession = {
   chatId: userMockChatId,
   messageApp: "Telegram",
@@ -74,11 +88,11 @@ const currentUserData_withFollows = {
   followedFunctions: exampleCurrentFollowedFunctions,
   followedNames: exampleFollowedNames,
   followedOrganisations: exampleFollowedOrganisations,
-  followedMeta: [],
+  followedMeta: exampleFollowedMeta,
   lastInteractionDay: Date.now(),
   lastInteractionMonth: Date.now(),
   lastInteractionWeek: Date.now(),
-  schemaVersion: 2,
+  schemaVersion: USER_SCHEMA_VERSION,
   createAt: Date.now(),
   updatedAt: Date.now()
 };
@@ -124,6 +138,18 @@ describe("User Model Test Suite", () => {
             lastUpdate: f.lastUpdate
           })
         );
+
+        userFromDBLean.followedMeta = userFromDBLean.followedMeta.map((m) => ({
+          module: m.module,
+          granularity: m.granularity,
+          identifier: m.identifier,
+          label: m.label,
+          filters: m.filters.map((filter) => ({
+            key: filter.key,
+            value: filter.value
+          })),
+          lastUpdate: m.lastUpdate
+        }));
 
         expect(userFromDBLean.schemaVersion).toBe(USER_SCHEMA_VERSION);
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,13 @@
 import { Model, Types } from "mongoose";
 import { FunctionTags } from "./entities/FunctionTags";
 import { Keyboard } from "./Keyboard.ts";
+import {
+  JORFSearchMetaFilter,
+  JORFSearchMetaGranularity,
+  JORFSearchMetaModule,
+  UserMetaFollowPreference
+} from "./entities/JORFSearchMetaItem.ts";
+export { UserMetaFollowPreference } from "./entities/JORFSearchMetaItem.ts";
 import umami from "./utils/umami";
 
 export interface CommandType {
@@ -50,10 +57,7 @@ export interface IUser {
     functionTag: FunctionTags;
     lastUpdate: Date;
   }[];
-  followedMeta: {
-    metaType: string;
-    lastUpdate: Date;
-  }[];
+  followedMeta: IUserFollowedMetaPreference[];
 
   lastMessageReceivedAt?: Date;
 
@@ -82,7 +86,24 @@ export interface IUser {
   removeFollowedPeople: (arg0: IPeople) => Promise<boolean>;
   removeFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   removeFollowedName: (arg0: string) => Promise<boolean>;
+  checkFollowedMeta: (arg0: UserMetaFollowPreference) => boolean;
+  addFollowedMeta: (
+    arg0: UserMetaFollowPreference
+  ) => Promise<boolean>;
+  removeFollowedMeta: (
+    arg0: UserMetaFollowPreference
+  ) => Promise<boolean>;
   followsNothing: () => boolean;
+}
+
+export interface IUserFollowedMetaFilter extends JORFSearchMetaFilter {}
+
+export interface IUserFollowedMetaPreference
+  extends UserMetaFollowPreference {
+  module: JORFSearchMetaModule;
+  granularity: JORFSearchMetaGranularity;
+  filters: IUserFollowedMetaFilter[];
+  lastUpdate: Date;
 }
 
 export interface IOrganisation {


### PR DESCRIPTION
## Summary
- define a modular metadata follow preference model for JORFSearch items
- extend the user schema, helper methods, and migration path to persist granular meta follows with lastUpdate timestamps
- refresh shared types and unit tests to exercise the upgraded meta follow structure

## Testing
- npm test *(fails: jest not available in environment because npm install is forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68d591c57714832d843af7ee4d53d342