### PR TITLE
Add granular follow preferences for JORF meta items

### DIFF
--- a/models/LegacyUser.ts
+++ b/models/LegacyUser.ts
@@ -1,6 +1,11 @@
 import { FunctionTags } from "../entities/FunctionTags.ts";
 import { Document, Types } from "mongoose";
-import { IUser, MessageApp, WikidataId } from "../types.ts";
+import {
+  FollowedMetaPreference,
+  IUser,
+  MessageApp,
+  WikidataId
+} from "../types.ts";
 
 export type IRawUser = LegacyRawUser_V2 | IUser;
 
@@ -23,10 +28,12 @@ export interface LegacyRawUser_V2 extends Document {
     functionTag: FunctionTags;
     lastUpdate: Date;
   }[];
-  followedMeta: {
-    metaType: string;
-    lastUpdate: Date;
-  }[];
+  followedMeta:
+    | {
+        metaType: string;
+        lastUpdate: Date;
+      }[]
+    | FollowedMetaPreference[];
 
   lastInteractionDay?: Date;
   lastInteractionWeek?: Date;

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,13 +1,70 @@
 import { Schema as _Schema, Types, model } from "mongoose";
 const Schema = _Schema;
 import umami from "../utils/umami.ts";
-import { ISession, IPeople, IUser, UserModel } from "../types.ts";
+import {
+  FollowedMetaGranularity,
+  FollowedMetaFilters,
+  ISession,
+  IPeople,
+  IUser,
+  UserModel
+} from "../types.ts";
 import { FunctionTags } from "../entities/FunctionTags.ts";
 import { loadUser } from "../entities/Session.ts";
 import { cleanPeopleName } from "../utils/JORFSearch.utils.ts";
 import { getISOWeek } from "../utils/date.utils.ts";
 
-export const USER_SCHEMA_VERSION = 2;
+export const USER_SCHEMA_VERSION = 3;
+
+const FollowedMetaFiltersSchema = new Schema<FollowedMetaFilters>(
+  {
+    nors: {
+      type: [String],
+      default: undefined
+    },
+    ministeres: {
+      type: [String],
+      default: undefined
+    },
+    autorites: {
+      type: [String],
+      default: undefined
+    },
+    tags: {
+      type: [String],
+      default: undefined
+    }
+  },
+  { _id: false }
+);
+
+const FollowedMetaPreferenceSchema = new Schema<{
+  metaId: string;
+  granularity: FollowedMetaGranularity;
+  filters?: FollowedMetaFilters;
+  lastUpdate: Date;
+}>(
+  {
+    metaId: {
+      type: String,
+      required: true
+    },
+    granularity: {
+      type: String,
+      enum: ["publication", "ministere", "autorite", "tag", "custom"],
+      default: "publication"
+    },
+    filters: {
+      type: FollowedMetaFiltersSchema,
+      default: undefined
+    },
+    lastUpdate: {
+      type: Date,
+      default: Date.now
+    }
+  },
+  { _id: false }
+);
 
 const UserSchema = new Schema<IUser, UserModel>(
   {
@@ -76,18 +133,7 @@ const UserSchema = new Schema<IUser, UserModel>(
       default: []
     },
     followedMeta: {
-      // Placeholder before implementation
-      type: [
-        {
-          metaType: {
-            type: String
-          },
-          lastUpdate: {
-            type: Date,
-            default: Date.now
-          }
-        }
-      ],
+      type: [FollowedMetaPreferenceSchema],
       default: []
     },
     schemaVersion: {

--- a/tests/02.user.test.ts
+++ b/tests/02.user.test.ts
@@ -27,6 +27,23 @@ const exampleFollowedOrganisations: IUser["followedOrganisations"] = [
   { wikidataId: "987654321", lastUpdate: new Date() }
 ];
 
+const exampleFollowedMeta: IUser["followedMeta"] = [
+  {
+    metaId: "JORFMETA000000000001",
+    granularity: "publication",
+    lastUpdate: new Date("2024-01-01T00:00:00.000Z")
+  },
+  {
+    metaId: "JORFMETA000000000002",
+    granularity: "tag",
+    filters: {
+      tags: ["mesure_nominative"],
+      ministeres: ["Ministère de la culture"]
+    },
+    lastUpdate: new Date("2024-02-02T00:00:00.000Z")
+  }
+];
+
 const MockTelegramSession = {
   chatId: userMockChatId,
   messageApp: "Telegram",
@@ -74,7 +91,7 @@ const currentUserData_withFollows = {
   followedFunctions: exampleCurrentFollowedFunctions,
   followedNames: exampleFollowedNames,
   followedOrganisations: exampleFollowedOrganisations,
-  followedMeta: [],
+  followedMeta: exampleFollowedMeta,
   lastInteractionDay: Date.now(),
   lastInteractionMonth: Date.now(),
   lastInteractionWeek: Date.now(),
@@ -171,6 +188,15 @@ describe("User Model Test Suite", () => {
 
         expect(userFromDBLean.followedNames).toEqual(
           user.data.followedNames ?? []
+        );
+
+        userFromDBLean.followedMeta = userFromDBLean.followedMeta.map(
+          ({ metaId, granularity, filters, lastUpdate }) => ({
+            metaId,
+            granularity,
+            filters,
+            lastUpdate
+          })
         );
 
         expect(userFromDBLean.followedMeta).toEqual(

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,6 @@
 import { Model, Types } from "mongoose";
 import { FunctionTags } from "./entities/FunctionTags";
+import { JORFSearchPublication } from "./entities/JORFSearchResponseMeta.ts";
 import { Keyboard } from "./Keyboard.ts";
 import umami from "./utils/umami";
 
@@ -50,10 +51,7 @@ export interface IUser {
     functionTag: FunctionTags;
     lastUpdate: Date;
   }[];
-  followedMeta: {
-    metaType: string;
-    lastUpdate: Date;
-  }[];
+  followedMeta: FollowedMetaPreference[];
 
   lastMessageReceivedAt?: Date;
 
@@ -83,6 +81,27 @@ export interface IUser {
   removeFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   removeFollowedName: (arg0: string) => Promise<boolean>;
   followsNothing: () => boolean;
+}
+
+export type FollowedMetaGranularity =
+  | "publication"
+  | "ministere"
+  | "autorite"
+  | "tag"
+  | "custom";
+
+export interface FollowedMetaFilters {
+  nors?: string[];
+  ministeres?: string[];
+  autorites?: string[];
+  tags?: (keyof JORFSearchPublication["tags"])[];
+}
+
+export interface FollowedMetaPreference {
+  metaId: string;
+  granularity: FollowedMetaGranularity;
+  filters?: FollowedMetaFilters;
+  lastUpdate: Date;
 }
 
 export interface IOrganisation {


### PR DESCRIPTION
## Summary
- add FollowedMetaPreference schema to persist granular JORF meta follow settings with per-preference lastUpdate values
- extend shared types and legacy-user definitions to cover the new meta follow structure
- update user model tests with representative meta follow fixtures

## Testing
- npm test -- --runTestsByPath tests/02.user.test.ts *(fails: jest binary not installed in environment)*
- npm install *(fails: npm registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d591c57714832d843af7ee4d53d342