### PR TITLE
Add reference-based grouping for organisation and function notifications

### DIFF
--- a/commands/followOrganisation.ts
+++ b/commands/followOrganisation.ts
@@ -22,6 +22,8 @@ interface WikiDataAPIResponse {
   }[];
 }
 
+const FULL_COMMAND_PROMPT = `\n\nFormat:\n*RechercherO Nom de l'organisation*\nou\n*RechercherO WikidataId de l'organisation*`;
+
 async function searchOrganisationWikidataId(
   org_name: string
 ): Promise<{ nom: string; wikidataId: WikidataId }[]> {
@@ -302,6 +304,7 @@ export const searchOrganisationFromStr = async (
 
     if (orgName)
       await processOrganisationSearch(session, orgName, triggerUmami);
+    else await session.sendMessage(FULL_COMMAND_PROMPT);
   } catch (error) {
     console.log(error);
   }

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -23,8 +23,8 @@ import {
 } from "./grouping.ts";
 
 const DEFAULT_GROUP_SEPARATOR = "====================\n\n";
-const DEFAULT_SUBGROUP_SEPARATOR = "--------------------\n\n";
-const DEFAULT_REFERENCE_SUBGROUP_SEPARATOR = "....................\n\n";
+const DEFAULT_SUBGROUP_SEPARATOR = "\n--------------------\n\n";
+const DEFAULT_REFERENCE_SUBGROUP_SEPARATOR = "\n....................\n\n";
 
 const tagValues = Object.values(FunctionTags);
 const tagKeys = Object.keys(FunctionTags);
@@ -37,7 +37,9 @@ const formatTagLeafGroup: LeafFormatter = (records, markdownEnabled, config) =>
     isConfirmation: false,
     isListing: true,
     displayName: "all",
-    omitOrganisationNames: config.omitOrganisationNames ?? false
+    omitOrganisationNames: config.omitOrganisationNames ?? false,
+    omitCabinet: true,
+    omitReference: true
   });
 
 const functionTagSeparatorSelector: SeparatorSelector = (level) =>

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -32,11 +32,7 @@ const tagKeys = Object.keys(FunctionTags);
 const CABINET_GROUP_FALLBACK_LABEL = "Autres ministères";
 const DEFAULT_REFERENCE_GROUPING = createReferenceGrouping();
 
-const formatTagLeafGroup: LeafFormatter = (
-  records,
-  markdownEnabled,
-  config
-) =>
+const formatTagLeafGroup: LeafFormatter = (records, markdownEnabled, config) =>
   formatSearchResult(records, markdownEnabled, {
     isConfirmation: false,
     isListing: true,
@@ -45,7 +41,9 @@ const formatTagLeafGroup: LeafFormatter = (
   });
 
 const functionTagSeparatorSelector: SeparatorSelector = (level) =>
-  level === 0 ? DEFAULT_SUBGROUP_SEPARATOR : DEFAULT_REFERENCE_SUBGROUP_SEPARATOR;
+  level === 0
+    ? DEFAULT_SUBGROUP_SEPARATOR
+    : DEFAULT_REFERENCE_SUBGROUP_SEPARATOR;
 
 const functionTagGroupingStrategies: Partial<
   Record<FunctionTags, NotificationGroupingConfig>
@@ -231,19 +229,14 @@ async function sendTagUpdates(
       functionTagSeparatorSelector
     );
 
-    if (formattedGroups.length > 0)
-      notification_text += formattedGroups;
+    if (formattedGroups.length > 0) notification_text += formattedGroups;
     else
-      notification_text += formatSearchResult(
-        tagRecords,
-        markdownLinkEnabled,
-        {
-          isConfirmation: false,
-          isListing: true,
-          displayName: "all",
-          omitOrganisationNames: groupingConfig.omitOrganisationNames ?? false
-        }
-      );
+      notification_text += formatSearchResult(tagRecords, markdownLinkEnabled, {
+        isConfirmation: false,
+        isListing: true,
+        displayName: "all",
+        omitOrganisationNames: groupingConfig.omitOrganisationNames ?? false
+      });
 
     if (tag !== lastTag) notification_text += DEFAULT_GROUP_SEPARATOR;
   }

--- a/notifications/grouping.ts
+++ b/notifications/grouping.ts
@@ -157,9 +157,7 @@ export function createReferenceGrouping(options?: {
         ? `${sourceName} du ${dateLabel} (${groupId})`
         : `${sourceName} (${groupId})`;
 
-      const wrappedLabel = markdownLinkEnabled
-        ? `*${label}*`
-        : `*${label}*`;
+      const wrappedLabel = markdownLinkEnabled ? `*${label}*` : `*${label}*`;
 
       return `📰 ${wrappedLabel}\n\n`;
     },

--- a/notifications/grouping.ts
+++ b/notifications/grouping.ts
@@ -1,0 +1,188 @@
+import { JORFSearchItem } from "../entities/JORFSearchResponse.ts";
+import { dateToFrenchString, JORFtoDate } from "../utils/date.utils.ts";
+
+export type GroupIdentifier = string | string[] | null | undefined;
+
+export interface NotificationGroupingConfig {
+  getGroupId: (record: JORFSearchItem) => GroupIdentifier;
+  fallbackLabel?: string;
+  formatGroupTitle?: (options: {
+    groupId: string;
+    markdownLinkEnabled: boolean;
+    records: JORFSearchItem[];
+  }) => string;
+  sortGroupIds?: (
+    groupIds: string[],
+    groupedMap: Map<string, JORFSearchItem[]>
+  ) => string[];
+  omitOrganisationNames?: boolean;
+  subGrouping?: NotificationGroupingConfig;
+}
+
+export type LeafFormatter = (
+  records: JORFSearchItem[],
+  markdownLinkEnabled: boolean,
+  config: NotificationGroupingConfig
+) => string;
+
+export type SeparatorSelector = (level: number) => string;
+
+function normaliseGroupId(id: string | null | undefined): string | null {
+  if (id === undefined || id === null) return null;
+  const trimmed = String(id).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function groupRecordsBy(
+  records: JORFSearchItem[],
+  config: NotificationGroupingConfig
+): Map<string, JORFSearchItem[]> {
+  const grouped = new Map<string, JORFSearchItem[]>();
+
+  for (const record of records) {
+    const rawGroupId = config.getGroupId(record);
+    const candidateIds = Array.isArray(rawGroupId) ? rawGroupId : [rawGroupId];
+
+    const validIds = candidateIds
+      .map((value) => normaliseGroupId(value))
+      .filter((value): value is string => value !== null);
+
+    const fallbackKey = normaliseGroupId(config.fallbackLabel);
+    const keysToUse =
+      validIds.length > 0 ? validIds : fallbackKey ? [fallbackKey] : [];
+
+    for (const key of keysToUse) {
+      const existing = grouped.get(key) ?? [];
+      existing.push(record);
+      grouped.set(key, existing);
+    }
+  }
+
+  return grouped;
+}
+
+export function orderGroupedEntries(
+  groupedMap: Map<string, JORFSearchItem[]>,
+  sort?: (
+    groupIds: string[],
+    groupedMap: Map<string, JORFSearchItem[]>
+  ) => string[]
+): [string, JORFSearchItem[]][] {
+  const groupIds = sort
+    ? sort([...groupedMap.keys()], groupedMap)
+    : [...groupedMap.keys()];
+  return groupIds.map((groupId) => [groupId, groupedMap.get(groupId) ?? []]);
+}
+
+export function formatGroupedRecords(
+  groupedMap: Map<string, JORFSearchItem[]>,
+  config: NotificationGroupingConfig,
+  markdownLinkEnabled: boolean,
+  leafFormatter: LeafFormatter,
+  separatorSelector: SeparatorSelector,
+  level = 0
+): string {
+  const orderedEntries = orderGroupedEntries(
+    groupedMap,
+    config.sortGroupIds
+  ).filter(([, records]) => records.length > 0);
+
+  if (orderedEntries.length === 0) return "";
+
+  return orderedEntries
+    .map(([groupId, groupRecords], index) => {
+      const title =
+        config.formatGroupTitle?.({
+          groupId,
+          markdownLinkEnabled,
+          records: groupRecords
+        }) ?? `👉 ${groupId}\n\n`;
+
+      const content = config.subGrouping
+        ? formatGroupedRecords(
+            groupRecordsBy(groupRecords, config.subGrouping),
+            config.subGrouping,
+            markdownLinkEnabled,
+            leafFormatter,
+            separatorSelector,
+            level + 1
+          )
+        : leafFormatter(groupRecords, markdownLinkEnabled, config);
+
+      const isLast = index === orderedEntries.length - 1;
+      const separator = !isLast ? separatorSelector(level) : "";
+
+      return `${title}${content}${separator}`;
+    })
+    .join("");
+}
+
+export function createFieldGrouping(
+  accessor: (record: JORFSearchItem) => GroupIdentifier,
+  options?: Omit<NotificationGroupingConfig, "getGroupId">
+): NotificationGroupingConfig {
+  return {
+    getGroupId: accessor,
+    fallbackLabel: options?.fallbackLabel,
+    formatGroupTitle: options?.formatGroupTitle,
+    sortGroupIds: options?.sortGroupIds,
+    omitOrganisationNames: options?.omitOrganisationNames,
+    subGrouping: options?.subGrouping
+  };
+}
+
+function getGroupDate(records: JORFSearchItem[]): Date | null {
+  if (!records.length) return null;
+  const date = records[0]?.source_date;
+  return date ? JORFtoDate(date) : null;
+}
+
+export function createReferenceGrouping(options?: {
+  formatGroupTitle?: NotificationGroupingConfig["formatGroupTitle"];
+  omitOrganisationNames?: boolean;
+}): NotificationGroupingConfig {
+  return {
+    getGroupId: (record) => record.source_id,
+    formatGroupTitle: (args) => {
+      if (options?.formatGroupTitle) return options.formatGroupTitle(args);
+
+      const { groupId, markdownLinkEnabled, records } = args;
+      const firstRecord = records[0];
+      const sourceName = firstRecord?.source_name ?? "Publication";
+      const dateLabel = firstRecord?.source_date
+        ? dateToFrenchString(firstRecord.source_date)
+        : null;
+
+      const label = dateLabel
+        ? `${sourceName} du ${dateLabel} (${groupId})`
+        : `${sourceName} (${groupId})`;
+
+      const wrappedLabel = markdownLinkEnabled
+        ? `*${label}*`
+        : `*${label}*`;
+
+      return `📰 ${wrappedLabel}\n\n`;
+    },
+    sortGroupIds: (groupIds, groupedMap) => {
+      return [...groupIds].sort((a, b) => {
+        const aRecords = groupedMap.get(a) ?? [];
+        const bRecords = groupedMap.get(b) ?? [];
+        const aDate = getGroupDate(aRecords);
+        const bDate = getGroupDate(bRecords);
+
+        if (aDate && bDate) {
+          if (aDate.getTime() !== bDate.getTime())
+            return bDate.getTime() - aDate.getTime();
+        } else if (aDate) {
+          return -1;
+        } else if (bDate) {
+          return 1;
+        }
+
+        return b.localeCompare(a, "fr", { sensitivity: "base" });
+      });
+    },
+    omitOrganisationNames: options?.omitOrganisationNames,
+    subGrouping: undefined
+  };
+}

--- a/notifications/grouping.ts
+++ b/notifications/grouping.ts
@@ -1,5 +1,6 @@
 import { JORFSearchItem } from "../entities/JORFSearchResponse.ts";
 import { dateToFrenchString, JORFtoDate } from "../utils/date.utils.ts";
+import { getJORFTextLink } from "../utils/JORFSearch.utils.ts";
 
 export type GroupIdentifier = string | string[] | null | undefined;
 
@@ -148,18 +149,16 @@ export function createReferenceGrouping(options?: {
 
       const { groupId, markdownLinkEnabled, records } = args;
       const firstRecord = records[0];
-      const sourceName = firstRecord?.source_name ?? "Publication";
-      const dateLabel = firstRecord?.source_date
-        ? dateToFrenchString(firstRecord.source_date)
-        : null;
+      const dateLabel = dateToFrenchString(firstRecord.source_date);
 
-      const label = dateLabel
-        ? `${sourceName} du ${dateLabel} (${groupId})`
-        : `${sourceName} (${groupId})`;
+      let label = `${firstRecord.source_name} du ${dateLabel}`;
+      const refLink = getJORFTextLink(groupId);
 
-      const wrappedLabel = markdownLinkEnabled ? `*${label}*` : `*${label}*`;
+      label += markdownLinkEnabled
+        ? `: [cliquez ici](${refLink})`
+        : `\n${refLink}`;
 
-      return `📰 ${wrappedLabel}\n\n`;
+      return `📰 ${label}\n\n`;
     },
     sortGroupIds: (groupIds, groupedMap) => {
       return [...groupIds].sort((a, b) => {

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -21,7 +21,7 @@ import {
 } from "./grouping.ts";
 
 const DEFAULT_GROUP_SEPARATOR = "====================\n\n";
-const DEFAULT_SUBGROUP_SEPARATOR = "--------------------\n\n";
+const DEFAULT_SUBGROUP_SEPARATOR = "\n--------------------\n\n";
 
 const organisationReferenceGrouping = createReferenceGrouping({
   omitOrganisationNames: true
@@ -36,7 +36,8 @@ const organisationLeafFormatter: LeafFormatter = (
     isConfirmation: false,
     isListing: true,
     displayName: "all",
-    omitOrganisationNames: config.omitOrganisationNames ?? false
+    omitOrganisationNames: config.omitOrganisationNames ?? false,
+    omitReference: true
   });
 
 const organisationSeparatorSelector: SeparatorSelector = () =>

--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -239,3 +239,7 @@ export function getJORFSearchLinkOrganisation(
     `https://jorfsearch.steinertriples.ch/${wikidataId}${json ? "?format=JSON" : ""}`
   );
 }
+
+export function getJORFTextLink(source_id: string) {
+  return encodeURI(`https://bodata.steinertriples.ch/${source_id}/redirect`);
+}

--- a/utils/formatting.utils.ts
+++ b/utils/formatting.utils.ts
@@ -10,81 +10,81 @@ export const textTypeOrdre = (
 
   switch (type_ordre) {
     case "nomination":
-      return `📝 A été _nommé${agree(sex)}_ à:\n`;
+      return `📝 A été _nommé${agree(sex)}_\n`;
     case "réintégration":
-      return `📝 A été _réintégré${agree(sex)}_:\n`;
+      return `📝 A été _réintégré${agree(sex)}_\n`;
     case "cessation de fonction":
-      return `📝 A _cessé ses fonctions_ à:\n`;
+      return `📝 A _cessé ses fonctions_\n`;
     case "affectation":
-      return `📝 A été _affecté${agree(sex)}_ à:\n`;
+      return `📝 A été _affecté${agree(sex)}_\n`;
     case "délégation de signature":
-      return `📝 A reçu${agree(sex)} une _délégation de signature_ à:\n`;
+      return `📝 A reçu${agree(sex)} une _délégation de signature_\n`;
     case "fin délégation signature":
-      return `📝 n'a plus la _délégation de signature_:\n`;
+      return `📝 n'a plus la _délégation de signature_\n`;
     case "promotion":
-      return `📝 A été _promu${agree(sex)}_:\n`;
+      return `📝 A été _promu${agree(sex)}_\n`;
     case "admission":
       return `📝 A été _admis${agree(sex)}_ \n`;
     case "inscription":
-      return `📝 A été _inscrit${agree(sex)}_ à:\n`;
+      return `📝 A été _inscrit${agree(sex)}_\n`;
     case "désignation":
-      return `📝 A été _désigné${agree(sex)}_ à:\n`;
+      return `📝 A été _désigné${agree(sex)}_\n`;
     case "détachement":
-      return `📝 A été _détaché${agree(sex)}_ à:\n`;
+      return `📝 A été _détaché${agree(sex)}_\n`;
     case "radiation":
-      return `📝 A été _radié${agree(sex)}_ à:\n`;
+      return `📝 A été _radié${agree(sex)}_\n`;
     case "renouvellement":
-      return `📝 A été _renouvelé${agree(sex)}_ à:\n`;
+      return `📝 A été _renouvelé${agree(sex)}_\n`;
     case "reconduction":
       return `📝 A été _reconduit${agree(sex)}_ dans ses fonctions\n`;
     case "élection":
-      return `📝 A été _élu${agree(sex)}_ à:\n`;
+      return `📝 A été _élu${agree(sex)}_\n`;
     case "admissibilité":
-      return `📝 A été _admissible_ à:\n`;
+      return `📝 A été _admissible_\n`;
     case "charge":
-      return `📝 A été _chargé${agree(sex)}_ de:\n`;
+      return `📝 A été _chargé${agree(sex)}_ de\n`;
     case "intégration":
-      return `📝 A été _intégré${agree(sex)}_ à:\n`;
+      return `📝 A été _intégré${agree(sex)}_\n`;
     //case "composition"
     case "habilitation":
-      return `📝 A été _habilité${agree(sex)}_ à:\n`;
+      return `📝 A été _habilité${agree(sex)}_\n`;
     case "titularisation":
-      return `📝 A été _titularisé${agree(sex)}_ à:\n`;
+      return `📝 A été _titularisé${agree(sex)}_\n`;
     case "recrutement":
-      return `📝 A été _recruté${agree(sex)}_:\n`;
+      return `📝 A été _recruté${agree(sex)}_\n`;
     case "disponibilité":
       return `📝 A été _mis${agree(sex)} en disponibilité_\n`;
     case "autorisation":
       return `📝 A été _autorisé${agree(sex)}_\n`;
     case "mise à disposition":
-      return `📝 A été _mis${agree(sex)} à disposition_\n`;
+      return `📝 A été _mis${agree(sex)} disposition_\n`;
     case "décharge":
       return `📝 A été _déchargé${agree(sex)}_\n`;
     case "diplome":
-      return `📝 A été _diplômé${agree(sex)}_ de:\n`;
+      return `📝 A été _diplômé${agree(sex)}_\n`;
     case "mutation":
-      return `📝 A été _muté${agree(sex)}_:\n`;
+      return `📝 A été _muté${agree(sex)}_\n`;
     case "décoration":
-      return `📝 A été _décoré${agree(sex)}_:\n`;
+      return `📝 A été _décoré${agree(sex)}_\n`;
     case "élévation":
-      return `📝 A été _élevé${agree(sex)}_:\n`;
+      return `📝 A été _élevé${agree(sex)}_\n`;
     case "transfert":
-      return `📝 A été _transféré${agree(sex)}_:\n`;
+      return `📝 A été _transféré${agree(sex)}_\n`;
     case "conféré":
-      return `📝 S'est vu${agree(sex)} _conféré${agree(sex)}_:\n`;
+      return `📝 S'est vu${agree(sex)} _conféré${agree(sex)}_\n`;
     case "citation":
-      return `📝 A été _cité${agree(sex)}_:\n`;
+      return `📝 A été _cité${agree(sex)}_\n`;
     case "démission":
-      return `📝 A _démissionné_:\n`;
+      return `📝 A _démissionné_\n`;
     case "attribution":
-      return `📝 S'est vu _attribué${agree(sex)}_:\n`;
+      return `📝 S'est vu _attribué${agree(sex)}_\n`;
     case "reprise de fonctions":
-      return `📝 A _repris ses fonctions_:\n`;
+      return `📝 A _repris ses fonctions_\n`;
     case "bourse":
-      return `📝 a reçu une _bourse_:\n`;
+      return `📝 a reçu une _bourse_\n`;
     case "prime":
-      return `📝 a reçu une _prime_:\n`;
+      return `📝 a reçu une _prime_\n`;
     default:
-      return `📝 A été _${type_ordre}_ à:\n`;
+      return `📝 A été _${type_ordre}_\n`;
   }
 };


### PR DESCRIPTION
## Summary
- add shared notification grouping utilities with support for reference-based ordering
- group organisation update notifications by JORF reference for clearer batching
- apply reference grouping to function-tag updates, including as subgroups within cabinet groups

## Testing
- npm test *(fails: jest not found; npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d5a8aa1124832da8bf55794d3ce7ec