### PR TITLE
Add command and follow-up manager Jest tests

### DIFF
--- a/tests/commands.processMessage.test.ts
+++ b/tests/commands.processMessage.test.ts
@@ -1,0 +1,330 @@
+import { jest } from "@jest/globals";
+
+describe("processMessage", () => {
+  const baseSession = (overrides: Partial<ReturnType<typeof defaultSession>> = {}) => ({
+    ...defaultSession(),
+    ...overrides
+  });
+
+  const defaultSession = () => ({
+    messageApp: "Telegram" as const,
+    chatId: 123,
+    language_code: "fr",
+    user: undefined,
+    isReply: false,
+    loadUser: jest.fn(),
+    createUser: jest.fn(),
+    sendMessage: jest.fn(),
+    sendTypingAction: jest.fn(),
+    log: jest.fn()
+  });
+
+  const registerSharedMocks = () => {
+    const noop = jest.fn().mockResolvedValue(undefined);
+
+    jest.unstable_mockModule("../commands/followOrganisation.ts", () => ({
+      searchOrganisation: noop,
+      searchOrganisationFromStr: noop,
+      followOrganisationsFromWikidataIdStr: noop
+    }));
+    jest.unstable_mockModule("../commands/search.ts", () => ({
+      followCommand: jest.fn().mockResolvedValue(undefined),
+      fullHistoryCommand: noop,
+      manualFollowCommand: noop,
+      searchCommand: jest.fn().mockResolvedValue(undefined),
+      searchPersonHistory: jest.fn().mockResolvedValue(undefined)
+    }));
+    jest.unstable_mockModule("../commands/ena.ts", () => ({
+      enaCommand: noop,
+      promosCommand: noop,
+      suivreFromJOReference: noop
+    }));
+    jest.unstable_mockModule("../commands/stats.ts", () => ({
+      statsCommand: noop
+    }));
+    jest.unstable_mockModule("../commands/deleteProfile.ts", () => ({
+      deleteProfileCommand: noop
+    }));
+    jest.unstable_mockModule("../commands/followFunction.ts", () => ({
+      followFunctionCommand: noop,
+      followFunctionFromStrCommand: noop
+    }));
+    jest.unstable_mockModule("../commands/list.ts", () => ({
+      listCommand: noop,
+      unfollowFromStr: noop
+    }));
+    jest.unstable_mockModule("../commands/help.ts", () => ({
+      buildInfoCommand: noop
+    }));
+    jest.unstable_mockModule("../commands/importExport.ts", () => ({
+      exportCommand: noop,
+      importCommand: noop
+    }));
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("normalises whitespace before routing to command handlers", async () => {
+    registerSharedMocks();
+    const session = defaultSession();
+
+    const searchCommand = jest.fn().mockResolvedValue(undefined);
+    const followCommand = jest.fn().mockResolvedValue(undefined);
+    jest.unstable_mockModule("../commands/search.ts", () => ({
+      followCommand,
+      fullHistoryCommand: jest.fn(),
+      manualFollowCommand: jest.fn(),
+      searchCommand,
+      searchPersonHistory: jest.fn().mockResolvedValue(undefined)
+    }));
+
+    const defaultCommand = jest.fn();
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {}
+    }));
+
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockResolvedValue(false);
+    const clearFollowUp = jest.fn();
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "   Rechercher   Alice    Martin   ");
+
+    expect(searchCommand).toHaveBeenCalledWith(
+      session,
+      "Rechercher Alice Martin"
+    );
+    expect(followCommand).not.toHaveBeenCalled();
+    expect(defaultCommand).not.toHaveBeenCalled();
+  });
+
+  it("invokes keyboard actions before command matching and clears follow-ups", async () => {
+    registerSharedMocks();
+    const session = defaultSession();
+
+    const keyboardAction = jest.fn().mockResolvedValue(undefined);
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {
+        TEST: { key: { text: "Button" }, action: keyboardAction }
+      }
+    }));
+
+    const defaultCommand = jest.fn();
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockResolvedValue(false);
+    const clearFollowUp = jest.fn();
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "Button\nignored");
+
+    expect(clearFollowUp).toHaveBeenCalledWith(session);
+    expect(keyboardAction).toHaveBeenCalledWith(session, "Button\nignored");
+    expect(handleFollowUpMessage).not.toHaveBeenCalled();
+    expect(defaultCommand).not.toHaveBeenCalled();
+  });
+
+  it("delegates to follow-up handlers and stops processing when they resolve", async () => {
+    registerSharedMocks();
+    const session = defaultSession();
+
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {}
+    }));
+
+    const defaultCommand = jest.fn();
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    const clearFollowUp = jest.fn();
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockImplementation(async () => {
+        clearFollowUp(session);
+        return true;
+      });
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "manual follow-up response");
+
+    expect(handleFollowUpMessage).toHaveBeenCalledWith(
+      session,
+      "manual follow-up response"
+    );
+    expect(defaultCommand).not.toHaveBeenCalled();
+  });
+
+  it("routes regex matches to the correct command handler", async () => {
+    registerSharedMocks();
+    const session = defaultSession();
+
+    const followCommand = jest.fn().mockResolvedValue(undefined);
+    jest.unstable_mockModule("../commands/search.ts", () => ({
+      followCommand,
+      fullHistoryCommand: jest.fn(),
+      manualFollowCommand: jest.fn(),
+      searchCommand: jest.fn(),
+      searchPersonHistory: jest.fn().mockResolvedValue(undefined)
+    }));
+
+    const defaultCommand = jest.fn();
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {}
+    }));
+
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockResolvedValue(false);
+    const clearFollowUp = jest.fn();
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "Suivre Marie Curie");
+
+    expect(followCommand).toHaveBeenCalledWith(
+      session,
+      "Suivre Marie Curie"
+    );
+    expect(defaultCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to default command when nothing matches", async () => {
+    registerSharedMocks();
+    const session = defaultSession();
+
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {}
+    }));
+
+    const defaultCommand = jest.fn();
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockResolvedValue(false);
+    const clearFollowUp = jest.fn();
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "something else");
+
+    expect(defaultCommand).toHaveBeenCalledWith(session);
+  });
+
+  it("does not send fallback content when processing reply messages", async () => {
+    registerSharedMocks();
+    const session = baseSession({ isReply: true });
+
+    jest.unstable_mockModule("../entities/Keyboard.ts", () => ({
+      KEYBOARD_KEYS: {}
+    }));
+
+    const defaultCommand = jest.fn(async (sess) => {
+      if (sess.isReply) return;
+      await sess.sendMessage("fallback");
+    });
+    jest.unstable_mockModule("../commands/default.ts", () => ({
+      defaultCommand,
+      MAIN_MENU_MESSAGE: "",
+      mainMenuCommand: jest.fn(),
+      sendMainMenu: jest.fn()
+    }));
+
+    jest.unstable_mockModule("../commands/start.ts", () => ({
+      startCommand: jest.fn()
+    }));
+
+    const handleFollowUpMessage = jest
+      .fn()
+      .mockResolvedValue(false);
+    const clearFollowUp = jest.fn();
+    jest.unstable_mockModule("../entities/FollowUpManager.ts", () => ({
+      handleFollowUpMessage,
+      clearFollowUp
+    }));
+
+    const { processMessage } = await import("../commands/Commands.ts");
+
+    await processMessage(session, "irrelevant");
+
+    expect(defaultCommand).toHaveBeenCalled();
+    expect(session.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands.start_default_help.test.ts
+++ b/tests/commands.start_default_help.test.ts
@@ -1,0 +1,196 @@
+import { jest } from "@jest/globals";
+
+describe("start, default and help commands", () => {
+  const createSession = (overrides: Record<string, unknown> = {}) => ({
+    messageApp: "Telegram",
+    chatId: 42,
+    language_code: "fr",
+    user: undefined,
+    isReply: false,
+    loadUser: jest.fn(),
+    createUser: jest.fn(),
+    sendMessage: jest.fn(),
+    sendTypingAction: jest.fn(),
+    log: jest.fn(),
+    ...overrides
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("sends help and logs /start for plain greetings", async () => {
+    const processMessage = jest.fn();
+    jest.unstable_mockModule("../commands/Commands.ts", () => ({
+      processMessage
+    }));
+
+    const getHelpText = jest.fn().mockReturnValue("help text");
+    jest.unstable_mockModule("../commands/help.ts", () => ({
+      getHelpText,
+      helpCommand: jest.fn(),
+      buildInfoCommand: jest.fn()
+    }));
+
+    const { startCommand } = await import("../commands/start.ts");
+    const session = createSession();
+
+    await startCommand(session, "/start");
+
+    expect(session.sendTypingAction).toHaveBeenCalled();
+    expect(getHelpText).toHaveBeenCalledWith(session);
+    expect(session.sendMessage).toHaveBeenCalledWith("help text", {
+      separateMenuMessage: true
+    });
+    expect(session.log).toHaveBeenCalledWith({ event: "/start" });
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches inline commands and logs contextual events", async () => {
+    const processMessage = jest.fn();
+    jest.unstable_mockModule("../commands/Commands.ts", () => ({
+      processMessage
+    }));
+
+    const getHelpText = jest.fn().mockReturnValue("help inline");
+    jest.unstable_mockModule("../commands/help.ts", () => ({
+      getHelpText,
+      helpCommand: jest.fn(),
+      buildInfoCommand: jest.fn()
+    }));
+
+    const { startCommand } = await import("../commands/start.ts");
+    const session = createSession();
+
+    await startCommand(session, "/start SuivreO Q42");
+
+    expect(session.sendMessage).toHaveBeenCalledWith("help inline", {
+      forceNoKeyboard: true
+    });
+    expect(session.log).toHaveBeenCalledWith({
+      event: "/start-from-organisation"
+    });
+    expect(processMessage).toHaveBeenCalledWith(session, "SuivreO Q42");
+
+    jest.clearAllMocks();
+
+    await startCommand(session, "/start SuivreF R01");
+    expect(session.log).toHaveBeenCalledWith({ event: "/start-from-tag" });
+    expect(processMessage).toHaveBeenLastCalledWith(session, "SuivreF R01");
+
+    jest.clearAllMocks();
+
+    await startCommand(session, "Bonjour JOEL ! Rechercher Marie Curie");
+    expect(session.log).toHaveBeenCalledWith({ event: "/start-from-people" });
+    expect(processMessage).toHaveBeenLastCalledWith(
+      session,
+      "Rechercher Marie Curie"
+    );
+  });
+
+  it("returns gracefully when no additional command is supplied", async () => {
+    const processMessage = jest.fn();
+    jest.unstable_mockModule("../commands/Commands.ts", () => ({
+      processMessage
+    }));
+
+    const getHelpText = jest.fn().mockReturnValue("help");
+    jest.unstable_mockModule("../commands/help.ts", () => ({
+      getHelpText,
+      helpCommand: jest.fn(),
+      buildInfoCommand: jest.fn()
+    }));
+
+    const { startCommand } = await import("../commands/start.ts");
+    const session = createSession();
+
+    await expect(startCommand(session, "Bonjour JOEL"))
+      .resolves.toBeUndefined();
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends fallback messaging and logging for defaultCommand", async () => {
+    const { defaultCommand } = await import("../commands/default.ts");
+    const session = createSession();
+
+    await defaultCommand(session);
+
+    expect(session.log).toHaveBeenCalledWith({ event: "/default-message" });
+    expect(session.sendMessage).toHaveBeenCalledWith(
+      "Je n'ai pas compris votre message 🥺",
+      { separateMenuMessage: true }
+    );
+  });
+
+  it("skips fallback messaging when handling replies", async () => {
+    const { defaultCommand } = await import("../commands/default.ts");
+    const session = createSession({ isReply: true });
+
+    await defaultCommand(session);
+
+    expect(session.log).not.toHaveBeenCalled();
+    expect(session.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("logs main menu requests and delegates to sendMainMenu", async () => {
+    const module = await import("../commands/default.ts");
+    const spy = jest
+      .spyOn(module, "sendMainMenu")
+      .mockResolvedValue(undefined as never);
+
+    const session = createSession({ messageApp: "Signal" });
+    await module.mainMenuCommand(session as any);
+
+    expect(session.log).toHaveBeenCalledWith({ event: "/main-menu-message" });
+    expect(spy).toHaveBeenCalledWith("Signal", 42, { session });
+  });
+
+  it("renders help differently for Telegram and other apps", async () => {
+    const module = await import("../commands/help.ts");
+
+    const telegramSession = createSession({ messageApp: "Telegram" });
+    await module.helpCommand(telegramSession);
+
+    expect(telegramSession.log).toHaveBeenCalledWith({ event: "/help" });
+    expect(telegramSession.sendTypingAction).toHaveBeenCalled();
+    const telegramHelp = (telegramSession.sendMessage as jest.Mock).mock.calls[0][0];
+    expect(telegramHelp).toContain("/export");
+    expect(telegramHelp).toContain("/supprimerCompte");
+    expect((telegramSession.sendMessage as jest.Mock).mock.calls[0][1]).toEqual({
+      separateMenuMessage: true
+    });
+
+    const signalSession = createSession({ messageApp: "Signal" });
+    await module.helpCommand(signalSession);
+    const signalHelp = (signalSession.sendMessage as jest.Mock).mock.calls[0][0];
+    expect(signalHelp).toContain("*Exporter*");
+    expect(signalHelp).not.toContain("/supprimerCompte");
+  });
+
+  it("builds help text by replacing placeholders", async () => {
+    const { getHelpText } = await import("../commands/help.ts");
+    const session = createSession({ chatId: 77, messageApp: "WhatsApp" });
+
+    const help = getHelpText(session);
+
+    expect(help).toContain(String(session.chatId));
+    expect(help).toContain(session.messageApp);
+    expect(help).toContain("Politique de confidentialité");
+    expect(help).toContain("Conditions générales d'utilisation");
+    expect(help).toContain("Rejoignez notre channel officiel");
+    expect(help).not.toContain("{CHAT_ID}");
+    expect(help).not.toContain("{MESSAGE_APP}");
+  });
+
+  it("sends blank informational messages via buildInfoCommand", async () => {
+    const { buildInfoCommand } = await import("../commands/help.ts");
+    const session = createSession();
+
+    await buildInfoCommand(session);
+
+    expect(session.sendMessage).toHaveBeenCalledWith("", {
+      separateMenuMessage: true
+    });
+  });
+});

--- a/tests/entities.followUpManager.test.ts
+++ b/tests/entities.followUpManager.test.ts
@@ -1,0 +1,109 @@
+import { jest } from "@jest/globals";
+import {
+  askFollowUpQuestion,
+  clearFollowUp,
+  handleFollowUpMessage,
+  hasFollowUp
+} from "../entities/FollowUpManager";
+
+describe("FollowUpManager", () => {
+  const createSession = (chatId = 123) => ({
+    messageApp: "Telegram" as const,
+    chatId,
+    sendMessage: jest.fn().mockResolvedValue(undefined)
+  });
+
+  const resetSession = (session) => {
+    clearFollowUp(session as any);
+  };
+
+  it("stores handlers, context and sends the provided question", async () => {
+    const session = createSession();
+    resetSession(session);
+
+    const handler = jest.fn().mockResolvedValue(true);
+    const options = {
+      context: { foo: "bar" },
+      messageOptions: { keyboard: [[{ text: "Test" }]] }
+    };
+
+    await askFollowUpQuestion(session as any, "Question?", handler, options);
+
+    expect(session.sendMessage).toHaveBeenCalledWith(
+      "Question?",
+      options.messageOptions
+    );
+    expect(hasFollowUp(session as any)).toBe(true);
+
+    const handled = await handleFollowUpMessage(session as any, "answer");
+    expect(handled).toBe(true);
+    expect(handler).toHaveBeenCalledWith(session, "answer", options.context);
+  });
+
+  it("skips sending empty questions while retaining the handler", async () => {
+    const session = createSession(456);
+    resetSession(session);
+
+    const handler = jest.fn().mockResolvedValue(true);
+    await askFollowUpQuestion(session as any, "", handler);
+
+    expect(session.sendMessage).not.toHaveBeenCalled();
+    expect(hasFollowUp(session as any)).toBe(true);
+    clearFollowUp(session as any);
+  });
+
+  it("rolls back state when sending the question fails", async () => {
+    const session = createSession(789);
+    resetSession(session);
+    session.sendMessage.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(
+      askFollowUpQuestion(session as any, "Will fail", jest.fn())
+    ).rejects.toThrow("boom");
+
+    expect(hasFollowUp(session as any)).toBe(false);
+  });
+
+  it("returns false when no follow-up is registered", async () => {
+    const session = createSession(100);
+    resetSession(session);
+
+    const handled = await handleFollowUpMessage(session as any, "ignored");
+    expect(handled).toBe(false);
+  });
+
+  it("invokes registered handler once and clears state before invocation", async () => {
+    const session = createSession(200);
+    resetSession(session);
+
+    const handler = jest
+      .fn()
+      .mockImplementation(async (_session, message, context) => {
+        expect(hasFollowUp(session as any)).toBe(false);
+        expect(message).toBe("Reply");
+        expect(context).toEqual({ tracked: true });
+        return true;
+      });
+
+    await askFollowUpQuestion(session as any, "Prompt", handler, {
+      context: { tracked: true }
+    });
+
+    const result = await handleFollowUpMessage(session as any, "Reply");
+
+    expect(result).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(hasFollowUp(session as any)).toBe(false);
+  });
+
+  it("can clear follow-ups proactively", async () => {
+    const session = createSession(300);
+    resetSession(session);
+
+    await askFollowUpQuestion(session as any, "Prompt", jest.fn(), {});
+    expect(hasFollowUp(session as any)).toBe(true);
+
+    clearFollowUp(session as any);
+    expect(hasFollowUp(session as any)).toBe(false);
+  });
+});

--- a/tests/utils.date.utils.test.ts
+++ b/tests/utils.date.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  JORFtoDate,
+  dateTOJORFFormat,
+  dateToFrenchString,
+  getISOWeek
+} from "../utils/date.utils.ts";
+
+describe("dateToFrenchString", () => {
+  it("formats ISO strings using French locale", () => {
+    expect(dateToFrenchString("2021-08-25T00:00:00.000Z")).toBe("25 août 2021");
+  });
+});
+
+describe("dateTOJORFFormat", () => {
+  it("zeroes time components and returns dd-mm-yyyy", () => {
+    const date = new Date("2024-02-18T10:30:00.000Z");
+    expect(dateTOJORFFormat(date)).toBe("18-02-2024");
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+});
+
+describe("JORFtoDate", () => {
+  it("parses yyyy-mm-dd strings", () => {
+    const date = JORFtoDate("2024-02-18");
+    expect(date.getFullYear()).toBe(2024);
+    expect(date.getMonth()).toBe(1);
+    expect(date.getDate()).toBe(18);
+  });
+});
+
+describe("getISOWeek", () => {
+  it("returns ISO week notation for year boundaries", () => {
+    expect(getISOWeek(new Date("2020-12-31T00:00:00.000Z"))).toBe("2020-W53");
+    expect(getISOWeek(new Date("2021-01-04T00:00:00.000Z"))).toBe("2021-W1");
+  });
+});

--- a/tests/utils.messageAppOptions.test.ts
+++ b/tests/utils.messageAppOptions.test.ts
@@ -1,0 +1,137 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from "@jest/globals";
+import { ErrorMessages } from "../entities/ErrorMessages.ts";
+import { WHATSAPP_API_VERSION } from "../entities/WhatsAppSession.ts";
+import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+import type { SignalCli } from "signal-sdk";
+
+const mockWhatsAppAPI = jest
+  .fn((config: Record<string, unknown>) => ({
+    ...config,
+    kind: "whatsAppAPI"
+  }) as unknown as WhatsAppAPI);
+
+const mockSignalConnect = jest.fn().mockResolvedValue(undefined);
+const mockSignalCli = jest
+  .fn((batPath: string, phone: string) => ({
+    connect: mockSignalConnect,
+    batPath,
+    phone
+  }) as unknown as SignalCli);
+
+await jest.unstable_mockModule("whatsapp-api-js/middleware/express", () => ({
+  WhatsAppAPI: mockWhatsAppAPI
+}));
+
+await jest.unstable_mockModule("signal-sdk", () => ({
+  SignalCli: mockSignalCli
+}));
+
+const {
+  parseEnabledMessageApps,
+  resolveExternalMessageOptions
+} = await import("../utils/messageAppOptions.ts");
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("parseEnabledMessageApps", () => {
+  it("throws when the env var is missing", () => {
+    delete process.env.ENABLED_APPS;
+    expect(() => parseEnabledMessageApps()).toThrow(
+      "ENABLED_APPS env var not set"
+    );
+  });
+
+  it("filters unsupported apps and logs a warning", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const enabled = parseEnabledMessageApps('["Telegram", "Fax"]');
+
+    expect(enabled).toEqual(["Telegram"]);
+    expect(warnSpy).toHaveBeenCalledWith("Ignoring unsupported apps: Fax");
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe("resolveExternalMessageOptions", () => {
+  it("throws if WhatsApp configuration is missing", async () => {
+    await expect(
+      resolveExternalMessageOptions(["WhatsApp"])
+    ).rejects.toThrow(ErrorMessages.WHATSAPP_ENV_NOT_SET);
+  });
+
+  it("throws if Signal configuration is missing", async () => {
+    await expect(
+      resolveExternalMessageOptions(["Signal"], {})
+    ).rejects.toThrow(ErrorMessages.SIGNAL_ENV_NOT_SET);
+  });
+
+  it("creates messaging clients when env vars are provided", async () => {
+    process.env.WHATSAPP_USER_TOKEN = "token";
+    process.env.WHATSAPP_APP_SECRET = "secret";
+    process.env.WHATSAPP_VERIFY_TOKEN = "verify";
+    process.env.SIGNAL_BAT_PATH = "/bin/signal";
+    process.env.SIGNAL_PHONE_NUMBER = "+33123456789";
+
+    const result = await resolveExternalMessageOptions([
+      "WhatsApp",
+      "Signal"
+    ]);
+
+    expect(mockWhatsAppAPI).toHaveBeenCalledWith({
+      token: "token",
+      appSecret: "secret",
+      webhookVerifyToken: "verify",
+      v: WHATSAPP_API_VERSION
+    });
+    expect(result.whatsAppAPI).toEqual({
+      token: "token",
+      appSecret: "secret",
+      webhookVerifyToken: "verify",
+      v: WHATSAPP_API_VERSION,
+      kind: "whatsAppAPI"
+    });
+
+    expect(mockSignalCli).toHaveBeenCalledWith(
+      "/bin/signal",
+      "+33123456789"
+    );
+    expect(mockSignalConnect).toHaveBeenCalledTimes(1);
+    expect(result.signalCli).toEqual({
+      connect: mockSignalConnect,
+      batPath: "/bin/signal",
+      phone: "+33123456789"
+    });
+  });
+
+  it("reuses provided messaging clients", async () => {
+    const existing = {
+      whatsAppAPI: { ready: true } as unknown as WhatsAppAPI,
+      signalCli: { connect: jest.fn() } as unknown as SignalCli
+    };
+
+    const result = await resolveExternalMessageOptions([
+      "WhatsApp",
+      "Signal"
+    ], existing);
+
+    expect(result).toBe(existing);
+    expect(mockWhatsAppAPI).not.toHaveBeenCalled();
+    expect(mockSignalCli).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils.text.utils.test.ts
+++ b/tests/utils.text.utils.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  convertToCSV,
+  escapeRegExp,
+  markdown2WHMarkdown,
+  markdown2html,
+  markdown2plainText,
+  parseIntAnswers,
+  removeSpecialCharacters,
+  splitText,
+  trimStrings
+} from "../utils/text.utils.ts";
+
+const sampleObjects = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 25 }
+] as unknown as never[];
+
+describe("splitText", () => {
+  it("respects newline and whitespace boundaries when chunking", () => {
+    const text = "\nfirst line\nsecond line\nthird";
+    expect(splitText(text, 12)).toEqual([
+      "first line",
+      "second line",
+      "third"
+    ]);
+  });
+
+  it("falls back to hard cuts when necessary", () => {
+    expect(splitText("abcdef", 3)).toEqual(["abc", "def"]);
+  });
+
+  it("returns the original text when max length is not positive", () => {
+    expect(splitText("hello", 0)).toEqual(["hello"]);
+  });
+});
+
+describe("parseIntAnswers", () => {
+  it("parses unique integers and ignores values above the limit", () => {
+    expect(parseIntAnswers("1, 2; 2 3 5", 3)).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array for undefined answers", () => {
+    expect(parseIntAnswers(undefined, 5)).toEqual([]);
+  });
+});
+
+describe("regex helpers", () => {
+  it("escapes regexp metacharacters", () => {
+    expect(escapeRegExp(".*test?$")).toBe("\\.\\*test\\?\\$");
+  });
+
+  it("removes regexp metacharacters", () => {
+    expect(removeSpecialCharacters(".*test?$")).toBe("test");
+  });
+});
+
+describe("convertToCSV", () => {
+  it("returns null for empty arrays", () => {
+    expect(convertToCSV([] as never[])).toBeNull();
+  });
+
+  it("serialises headers and rows for non-empty arrays", () => {
+    expect(convertToCSV(sampleObjects)).toBe("name,age\\nAlice,30\\nBob,25");
+  });
+});
+
+describe("trimStrings", () => {
+  it("trims nested strings recursively", () => {
+    const payload = {
+      name: " Alice ",
+      nested: [" Bob ", { inner: " Carol " }],
+      untouched: 42
+    };
+
+    expect(trimStrings(payload)).toEqual({
+      name: "Alice",
+      nested: ["Bob", { inner: "Carol" }],
+      untouched: 42
+    });
+  });
+});
+
+describe("markdown helpers", () => {
+  it("strips markdown formatting, emojis and accents", () => {
+    expect(markdown2plainText("Élève *monde*😀"))
+      .toBe("Eleve monde");
+  });
+
+  it("converts markdown links to WhatsApp friendly format", () => {
+    expect(markdown2WHMarkdown("See [docs](https://example.com)"))
+      .toBe("See *docs*\\nhttps://example.com");
+  });
+
+  it("turns inline markdown into HTML", () => {
+    expect(
+      markdown2html(
+        "Visit [site](https://example.com) and *bold* plus _italic_"
+      )
+    ).toBe(
+      'Visit <a href="https://example.com" rel="noopener noreferrer">site</a> ' +
+        "and <strong>bold</strong> plus <em>italic</em>"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for processMessage, ensuring keyboard routing, follow-up handling, whitespace normalization, and default fallbacks
- exercise start/default/help command flows including inline /start dispatch, help content, and menu logging behaviour
- validate follow-up manager lifecycle covering ask/handle flows, error rollback, and manual clearing

## Testing
- npm test *(fails: jest binary missing in execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ef76568194832db0ebb9df7b7735ee