### PR TITLE
Add coverage for database connection and notification dispatch

### DIFF
--- a/tests/db.mongodbConnect.test.ts
+++ b/tests/db.mongodbConnect.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from "@jest/globals";
+import { ErrorMessages } from "../entities/ErrorMessages.ts";
+
+const connectMock = jest.fn();
+
+await jest.unstable_mockModule("mongoose", () => ({
+  default: { connect: connectMock },
+  connect: connectMock
+}));
+
+const { mongodbConnect } = await import("../db.ts");
+
+const ORIGINAL_ENV = process.env.MONGODB_URI;
+
+describe("mongodbConnect", () => {
+  beforeEach(() => {
+    connectMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.MONGODB_URI;
+    } else {
+      process.env.MONGODB_URI = ORIGINAL_ENV;
+    }
+  });
+
+  it("throws when MONGODB_URI is missing", async () => {
+    delete process.env.MONGODB_URI;
+
+    await expect(mongodbConnect()).rejects.toThrow(
+      ErrorMessages.MONGODB_URI_NOT_SET
+    );
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  it("connects using the provided URI", async () => {
+    const uri = "mongodb://example.test/database";
+    process.env.MONGODB_URI = uri;
+    connectMock.mockResolvedValueOnce(undefined);
+
+    await expect(mongodbConnect()).resolves.toBeUndefined();
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(connectMock).toHaveBeenCalledWith(uri);
+  });
+});

--- a/tests/entities.errorMessages.test.ts
+++ b/tests/entities.errorMessages.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+import { ErrorMessages } from "../entities/ErrorMessages.ts";
+
+const expectedEntries: Array<[keyof typeof ErrorMessages, string]> = [
+  [
+    "MONGODB_URI_NOT_SET",
+    "MONGODB_URI is not set. Please set it in your .env file"
+  ],
+  [
+    "TELEGRAM_BOT_TOKEN_NOT_SET",
+    "BOT_TOKEN is not set. Please set it in your .env file"
+  ],
+  [
+    "WHATSAPP_ENV_NOT_SET",
+    "WHATSAPP_ENV variables are not set. Please set it in your .env file"
+  ],
+  [
+    "SIGNAL_ENV_NOT_SET",
+    "SIGNAL_ENV variables are not set. Please set it in your .env file"
+  ]
+];
+
+describe("ErrorMessages enum", () => {
+  it("exposes all expected error messages", () => {
+    expect(Object.keys(ErrorMessages).sort()).toEqual(
+      expectedEntries.map(([key]) => key).sort()
+    );
+  });
+
+  it("matches the documented message strings", () => {
+    for (const [key, expectedMessage] of expectedEntries) {
+      expect(ErrorMessages[key]).toBe(expectedMessage);
+    }
+  });
+});

--- a/tests/utils.notificationDispatch.test.ts
+++ b/tests/utils.notificationDispatch.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Types } from "mongoose";
+import type { MessageApp } from "../types.ts";
+
+type NotificationTask<T> = import("../utils/notificationDispatch.ts").NotificationTask<T>;
+
+const limiterMocks: jest.Mock[] = [];
+const pLimitMock = jest.fn(() => {
+  const limiter = jest.fn(async (fn: () => Promise<void> | void) => fn());
+  limiterMocks.push(limiter);
+  return limiter;
+});
+
+await jest.unstable_mockModule("p-limit", () => ({
+  default: pLimitMock
+}));
+
+await jest.unstable_mockModule("../entities/TelegramSession.ts", () => ({
+  TELEGRAM_API_SENDING_CONCURRENCY: 2
+}));
+
+await jest.unstable_mockModule("../entities/WhatsAppSession.ts", () => ({
+  WHATSAPP_API_SENDING_CONCURRENCY: 3
+}));
+
+await jest.unstable_mockModule("../entities/SignalSession.ts", () => ({
+  SIGNAL_API_SENDING_CONCURRENCY: 1
+}));
+
+const { dispatchTasksToMessageApps } = await import("../utils/notificationDispatch.ts");
+
+describe("dispatchTasksToMessageApps", () => {
+  beforeEach(() => {
+    limiterMocks.length = 0;
+    pLimitMock.mockClear();
+  });
+
+  it("groups tasks per message app, sorts by record count, and applies concurrency limits", async () => {
+    const taskFactory = (
+      messageApp: MessageApp,
+      recordCount: number
+    ): NotificationTask<string> => ({
+      userId: new Types.ObjectId(),
+      messageApp,
+      chatId: `chat-${messageApp}-${recordCount}`,
+      updatedRecordsMap: new Map(),
+      recordCount
+    });
+
+    const tasks: NotificationTask<string>[] = [
+      taskFactory("Signal", 1),
+      taskFactory("Telegram", 4),
+      taskFactory("WhatsApp", 3),
+      taskFactory("Telegram", 2),
+      taskFactory("Signal", 5)
+    ];
+
+    const perAppOrder = new Map<MessageApp, number[]>();
+    const taskHandler = jest.fn(async (task: NotificationTask<string>) => {
+      const sequence = perAppOrder.get(task.messageApp) ?? [];
+      sequence.push(task.recordCount);
+      perAppOrder.set(task.messageApp, sequence);
+    });
+
+    await dispatchTasksToMessageApps(tasks, taskHandler);
+
+    expect(tasks.map((task) => task.recordCount)).toEqual([5, 4, 3, 2, 1]);
+
+    expect(perAppOrder.get("Signal")).toEqual([5, 1]);
+    expect(perAppOrder.get("Telegram")).toEqual([4, 2]);
+    expect(perAppOrder.get("WhatsApp")).toEqual([3]);
+
+    expect(taskHandler).toHaveBeenCalledTimes(tasks.length);
+
+    expect(pLimitMock.mock.calls).toEqual([[1], [2], [3]]);
+
+    expect(limiterMocks).toHaveLength(3);
+    expect(limiterMocks[0].mock.calls).toHaveLength(2); // Signal has two tasks
+    expect(limiterMocks[1].mock.calls).toHaveLength(2); // Telegram has two tasks
+    expect(limiterMocks[2].mock.calls).toHaveLength(1); // WhatsApp has one task
+  });
+});


### PR DESCRIPTION
## Summary
- add a mongodbConnect test to ensure it enforces MONGODB_URI and connects via mongoose
- add an ErrorMessages enum test to lock down documented message strings
- add notification dispatch coverage to verify per-app grouping, ordering, and concurrency limits

## Testing
- npm test *(fails: jest binary unavailable in environment and npm install 403s)*

------
https://chatgpt.com/codex/tasks/task_b_68ef79b5670c832da77289bdf0d7f6da