### PR TITLE
Automate notification scheduling within messaging apps

### DIFF
--- a/apps/signalApp.ts
+++ b/apps/signalApp.ts
@@ -5,6 +5,7 @@ import { mongodbConnect } from "../db.ts";
 import { SignalSession } from "../entities/SignalSession.ts";
 import { processMessage } from "../commands/Commands.ts";
 import umami from "../utils/umami.ts";
+import { startDailyNotificationJob } from "../notifications/notificationScheduler.ts";
 
 const { SIGNAL_PHONE_NUMBER, SIGNAL_BAT_PATH } = process.env;
 
@@ -76,6 +77,8 @@ await (async () => {
     });
 
     console.log(`Signal: JOEL started successfully \u{2705}`);
+
+    startDailyNotificationJob("Signal");
 
     // Graceful shutdown
     //await signal.gracefulShutdown();

--- a/apps/telegramApp.ts
+++ b/apps/telegramApp.ts
@@ -6,6 +6,7 @@ import { TelegramSession } from "../entities/TelegramSession.ts";
 import { processMessage } from "../commands/Commands.ts";
 import umami from "../utils/umami.ts";
 import { ErrorMessages } from "../entities/ErrorMessages.ts";
+import { startDailyNotificationJob } from "../notifications/notificationScheduler.ts";
 
 const BOT_TOKEN = process.env.BOT_TOKEN;
 if (BOT_TOKEN === undefined) {
@@ -45,4 +46,6 @@ await (async () => {
   console.log(`Telegram: JOEL started successfully \u{2705}`);
 
   await bot.launch();
+
+  startDailyNotificationJob("Telegram");
 })();

--- a/apps/whatsAppApp.ts
+++ b/apps/whatsAppApp.ts
@@ -16,6 +16,7 @@ import {
   WhatsAppSession
 } from "../entities/WhatsAppSession.ts";
 import { processMessage } from "../commands/Commands.ts";
+import { startDailyNotificationJob } from "../notifications/notificationScheduler.ts";
 
 const MAX_AGE_SEC = 5 * 60;
 
@@ -243,6 +244,8 @@ await (async function () {
   await mongodbConnect();
 
   console.log(`WhatsApp: JOEL started successfully \u{2705}`);
+
+  startDailyNotificationJob("WhatsApp");
 })();
 
 // Define an interface for the potential message-containing object

--- a/notifications/notificationScheduler.ts
+++ b/notifications/notificationScheduler.ts
@@ -1,0 +1,84 @@
+import "dotenv/config";
+import { MessageApp } from "../types.ts";
+import { runNotificationProcess } from "./runNotificationProcess.ts";
+
+const DAILY_NOTIFICATION_TIME_ENV = "DAILY_NOTIFICATION_TIME";
+
+type DailyTime = {
+  hour: number;
+  minute: number;
+};
+
+function parseDailyTime(value: string): DailyTime {
+  const match = value.trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (match == null) {
+    throw new Error(
+      `Invalid ${DAILY_NOTIFICATION_TIME_ENV} format. Expected HH:MM, received "${value}".`
+    );
+  }
+
+  const hour = Number.parseInt(match[1], 10);
+  const minute = Number.parseInt(match[2], 10);
+
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    throw new Error(
+      `${DAILY_NOTIFICATION_TIME_ENV} must be a valid 24h time. Received ${value}.`
+    );
+  }
+
+  return { hour, minute };
+}
+
+function computeNextOccurrence({ hour, minute }: DailyTime): Date {
+  const now = new Date();
+  const next = new Date(now);
+  next.setHours(hour, minute, 0, 0);
+  if (next.getTime() <= now.getTime()) {
+    next.setDate(next.getDate() + 1);
+  }
+  return next;
+}
+
+export function startDailyNotificationJob(appType: MessageApp): void {
+  const configuredTime = process.env[DAILY_NOTIFICATION_TIME_ENV];
+  if (configuredTime == null) {
+    throw new Error(
+      `${DAILY_NOTIFICATION_TIME_ENV} environment variable must be defined to schedule notifications.`
+    );
+  }
+
+  const parsedTime = parseDailyTime(configuredTime);
+
+  let running = false;
+
+  const scheduleNextRun = () => {
+    const nextRun = computeNextOccurrence(parsedTime);
+    const delay = nextRun.getTime() - Date.now();
+
+    setTimeout(async () => {
+      if (running) {
+        console.warn(
+          `${appType}: notification process is still running when the next schedule fired. Skipping this cycle.`
+        );
+        scheduleNextRun();
+        return;
+      }
+
+      running = true;
+      try {
+        await runNotificationProcess(appType);
+      } catch (error) {
+        console.error(`${appType}: error during notification process`, error);
+      } finally {
+        running = false;
+        scheduleNextRun();
+      }
+    }, delay);
+
+    console.log(
+      `${appType}: next notification process scheduled for ${nextRun.toISOString()}`
+    );
+  };
+
+  scheduleNextRun();
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "start-wh": "tsx apps/whatsAppApp.ts",
     "start-si": "tsx apps/signalApp.ts",
     "lint": "eslint .",
-    "notify": "tsx notifications/notifyUsers.ts",
     "lint:fix": "eslint . --fix",
     "test": "jest --config=jest.config.js"
   },


### PR DESCRIPTION
## Summary
- refactor the notification runner into a reusable `runNotificationProcess` that targets a single messaging app at a time
- add a daily scheduler driven by the `DAILY_NOTIFICATION_TIME` environment variable and wire it into the Telegram, WhatsApp, and Signal apps
- remove the standalone `npm run notify` script in favor of per-app automation

## Testing
- npm run lint *(fails: Cannot find package 'eslint')*
- npm test *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68f535db251c832d9e565137d74d7335