### PR TITLE
Add support for \split command in splitText

### DIFF
--- a/tests/splitText.test.ts
+++ b/tests/splitText.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import { splitText } from "../utils/text.utils.ts";
+
+describe("splitText", () => {
+  it("forces a split when the \\split command is present", () => {
+    const result = splitText("Hello\\splitWorld", 100);
+    expect(result).toEqual(["Hello", "World"]);
+  });
+
+  it("removes the \\split command from the output", () => {
+    const result = splitText("Part 1 \\split Part 2", 100);
+    expect(result).toEqual(["Part 1 ", " Part 2"]);
+    const recombined = result.join("");
+    expect(recombined).toBe("Part 1  Part 2");
+    expect(recombined).not.toContain("\\split");
+  });
+
+  it("continues to respect the max length within each forced segment", () => {
+    const result = splitText("AAAAAAAAAA\\splitBBBBBBBBBB", 4);
+    expect(result).toEqual(["AAAA", "AAAA", "AA", "BBBB", "BBBB", "BB"]);
+  });
+
+  it("handles consecutive split commands without creating empty chunks", () => {
+    const result = splitText("First\\split\\splitSecond", 100);
+    expect(result).toEqual(["First", "Second"]);
+  });
+});

--- a/utils/text.utils.ts
+++ b/utils/text.utils.ts
@@ -8,39 +8,25 @@ export function splitText(text: string, max: number): string[] {
   if (!Number.isFinite(max) || max <= 0) return [text];
 
   const chunks: string[] = [];
-  const n = text.length;
-  let i = 0;
+  const FORCE_SPLIT = "\\split";
+  const segments: string[] = [];
 
-  while (i < n) {
-    // Skip leading newlines
-    while (i < n && (text[i] === "\n" || text[i] === "\r")) i++;
-    if (i >= n) break;
-
-    let end = Math.min(i + max, n);
-
-    if (end < n) {
-      // 1) Prefer a newline within [i, end)
-      const nl = Math.max(
-        text.lastIndexOf("\n", end - 1),
-        text.lastIndexOf("\r", end - 1)
-      );
-      if (nl >= i) {
-        end = nl;
-      } else {
-        // 2) Otherwise prefer last whitespace within [i, end)
-        let j = end;
-        while (j > i && !isSpace(text.charCodeAt(j - 1))) j--;
-        if (j > i) end = j;
-      }
+  let start = 0;
+  while (true) {
+    const idx = text.indexOf(FORCE_SPLIT, start);
+    if (idx === -1) {
+      segments.push(text.slice(start));
+      break;
     }
 
-    // 3) If we couldn't find a better break, hard-cut at max to ensure progress
-    if (end === i) end = Math.min(i + max, n);
+    segments.push(text.slice(start, idx));
+    start = idx + FORCE_SPLIT.length;
+  }
 
-    const chunk = trimEdgeNewlines(text.slice(i, end));
-    if (chunk.length) chunks.push(chunk);
-
-    i = end;
+  for (const segment of segments) {
+    appendSegment(segment);
+    // Processing each segment independently automatically enforces the
+    // explicit split markers—no extra state required here.
   }
 
   return chunks;
@@ -56,6 +42,43 @@ export function splitText(text: string, max: number): string[] {
     while (b > a && (s.charCodeAt(b - 1) === 10 || s.charCodeAt(b - 1) === 13))
       b--;
     return s.slice(a, b);
+  }
+
+  function appendSegment(segmentText: string): void {
+    const n = segmentText.length;
+    let i = 0;
+
+    while (i < n) {
+      // Skip leading newlines
+      while (i < n && (segmentText[i] === "\n" || segmentText[i] === "\r")) i++;
+      if (i >= n) break;
+
+      let end = Math.min(i + max, n);
+
+      if (end < n) {
+        // 1) Prefer a newline within [i, end)
+        const nl = Math.max(
+          segmentText.lastIndexOf("\n", end - 1),
+          segmentText.lastIndexOf("\r", end - 1)
+        );
+        if (nl >= i) {
+          end = nl;
+        } else {
+          // 2) Otherwise prefer last whitespace within [i, end)
+          let j = end;
+          while (j > i && !isSpace(segmentText.charCodeAt(j - 1))) j--;
+          if (j > i) end = j;
+        }
+      }
+
+      // 3) If we couldn't find a better break, hard-cut at max to ensure progress
+      if (end === i) end = Math.min(i + max, n);
+
+      const chunk = trimEdgeNewlines(segmentText.slice(i, end));
+      if (chunk.length) chunks.push(chunk);
+
+      i = end;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- update `splitText` to recognize `\split` markers and force message boundaries without keeping the marker in the output
- process each forced segment with the existing wrapping logic so standard length handling still applies
- add focused unit tests to cover the new forced-split behaviour and guard against regressions

## Testing
- npx jest --config=jest.config.js splitText *(fails: npm 403 when fetching jest)*

------
https://chatgpt.com/codex/tasks/task_b_68fa2dc8e374832d8ec9acbc68793d7e