### PR TITLE
Harden MongoDB usage with TLS and guarded queries

### DIFF
--- a/commands/deleteProfile.ts
+++ b/commands/deleteProfile.ts
@@ -2,6 +2,7 @@ import User from "../models/User.ts";
 import { ISession } from "../types.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
 import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 const DELETE_PROFILE_CONFIRMATION_PROMPT =
   "*Vous êtes sur le point de supprimer votre profil JOÉL*, comprenant l'ensemble de vos contacts, fonctions et organisations suivis.\n" +
@@ -42,9 +43,11 @@ async function handleDeleteProfileAnswer(
   }
 
   if (trimmedAnswer === "SUPPRIMER MON COMPTE") {
-    await User.deleteOne({
-      _id: session.user._id
-    });
+    await User.deleteOne(
+      guardFilter({
+        _id: session.user._id
+      })
+    );
     session.user = null;
     await session.sendMessage(
       `🗑 Votre profil a bien été supprimé ! 👋\\splitUn profil vierge sera créé lors de l'ajout du prochain suivi ⚠️`

--- a/commands/followOrganisation.ts
+++ b/commands/followOrganisation.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/JORFSearch.utils.ts";
 import { Keyboard, KEYBOARD_KEYS } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 const isOrganisationAlreadyFollowed = (
   user: IUser,
@@ -332,9 +333,11 @@ export const followOrganisationsFromWikidataIdStr = async (
 
     const orgResults: IOrganisation[] = [];
 
-    const orgsInDb: IOrganisation[] = await Organisation.find({
-      wikidataId: { $in: selectedWikiDataIds }
-    }).lean();
+    const orgsInDb: IOrganisation[] = await Organisation.find(
+      guardFilter({
+        wikidataId: { $in: selectedWikiDataIds }
+      })
+    ).lean();
     for (const id of selectedWikiDataIds) {
       const orgFromDb: IOrganisation | undefined = orgsInDb.find(
         (o) => o.wikidataId === id

--- a/commands/importExport.ts
+++ b/commands/importExport.ts
@@ -11,6 +11,7 @@ import {
 } from "./list.ts";
 import { cleanPeopleName } from "../utils/JORFSearch.utils.ts";
 import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 const EXPORT_CODE_VALIDITY_MS = 4 * 60 * 60 * 1000; // 4 hours
 
@@ -83,9 +84,11 @@ async function handleImporterCode(
     return true;
   }
 
-  const sourceUser: IUser | null = await User.findOne({
-    "transferData.code": code
-  });
+  const sourceUser: IUser | null = await User.findOne(
+    guardFilter({
+      "transferData.code": code
+    })
+  );
 
   if (
     sourceUser?.transferData == null ||
@@ -160,9 +163,11 @@ async function handleImporterConfirmation(
       return true;
     }
 
-    const sourceUser: IUser | null = await User.findOne({
-      _id: context.sourceUserId
-    });
+    const sourceUser: IUser | null = await User.findOne(
+      guardFilter({
+        _id: context.sourceUserId
+      })
+    );
 
     if (
       sourceUser?.transferData == null ||

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/JORFSearch.utils.ts";
 import { Keyboard, KEYBOARD_KEYS } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 export interface UserFollows {
   functions: FunctionTags[];
@@ -131,9 +132,11 @@ export async function getAllUserFollowsOrdered(
 
   let followedOrganisations: IOrganisation[] = [];
   if (user.followedOrganisations.length > 0)
-    followedOrganisations = await Organisation.find({
-      wikidataId: { $in: user.followedOrganisations.map((o) => o.wikidataId) }
-    }).lean();
+    followedOrganisations = await Organisation.find(
+      guardFilter({
+        wikidataId: { $in: user.followedOrganisations.map((o) => o.wikidataId) }
+      })
+    ).lean();
 
   followedOrganisations.sort((a, b) =>
     a.nom.toUpperCase().localeCompare(b.nom.toUpperCase())
@@ -141,9 +144,11 @@ export async function getAllUserFollowsOrdered(
 
   let followedPeoples: IPeople[] = [];
   if (user.followedPeople.length > 0)
-    followedPeoples = await People.find({
-      _id: { $in: user.followedPeople.map((p) => p.peopleId) }
-    }).lean();
+    followedPeoples = await People.find(
+      guardFilter({
+        _id: { $in: user.followedPeople.map((p) => p.peopleId) }
+      })
+    ).lean();
 
   const followedPeopleTab: {
     nomPrenom: string;
@@ -473,7 +478,7 @@ export const unfollowFromStr = async (
 
     // Delete the user if it doesn't follow anything any more
     if (session.user.followsNothing()) {
-      await User.deleteOne({ _id: session.user._id });
+      await User.deleteOne(guardFilter({ _id: session.user._id }));
       await session.log({ event: "/user-deletion-no-follow" });
     }
 

--- a/commands/search.ts
+++ b/commands/search.ts
@@ -11,6 +11,7 @@ import { JORFSearchItem } from "../entities/JORFSearchResponse.ts";
 import { removeSpecialCharacters } from "../utils/text.utils.ts";
 import { Keyboard, KEYBOARD_KEYS } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 const isPersonAlreadyFollowed = (
   person: IPeople,
@@ -193,14 +194,18 @@ export async function searchPersonHistory(
     }
     let numberFollowers: number | undefined;
 
-    peopleFromDB ??= await People.findOne({
-      nom: JORFRes_data[0].nom,
-      prenom: JORFRes_data[0].prenom
-    });
+    peopleFromDB ??= await People.findOne(
+      guardFilter({
+        nom: JORFRes_data[0].nom,
+        prenom: JORFRes_data[0].prenom
+      })
+    );
     if (peopleFromDB != null) {
-      numberFollowers = await User.countDocuments({
-        followedPeople: { $elemMatch: { peopleId: peopleFromDB._id } }
-      });
+      numberFollowers = await User.countDocuments(
+        guardFilter({
+          followedPeople: { $elemMatch: { peopleId: peopleFromDB._id } }
+        })
+      );
     }
 
     let text = "";
@@ -228,10 +233,12 @@ export async function searchPersonHistory(
     if (session.user == null) {
       isUserFollowingPerson = false;
     } else {
-      const people: IPeople | null = await People.findOne({
-        nom: JORFRes_data[0].nom,
-        prenom: JORFRes_data[0].prenom
-      })
+      const people: IPeople | null = await People.findOne(
+        guardFilter({
+          nom: JORFRes_data[0].nom,
+          prenom: JORFRes_data[0].prenom
+        })
+      )
         .collation({ locale: "fr", strength: 2 }) // case-insensitive, no regex
         .lean();
 

--- a/db.ts
+++ b/db.ts
@@ -1,9 +1,54 @@
 import mongoose from "mongoose";
 import { ErrorMessages } from "./entities/ErrorMessages.ts";
 
+mongoose.set("sanitizeFilter", true);
+mongoose.set("strictQuery", true);
+
 export const mongodbConnect = async () => {
-  if (!process.env.MONGODB_URI) {
+  const {
+    MONGODB_URI,
+    MONGODB_USERNAME,
+    MONGODB_PASSWORD,
+    MONGODB_DB_NAME,
+    MONGODB_TLS_CA_FILE,
+    MONGODB_AUTH_SOURCE,
+    MONGODB_TLS_CERT_KEY_FILE
+  } = process.env;
+
+  if (!MONGODB_URI) {
     throw new Error(ErrorMessages.MONGODB_URI_NOT_SET);
   }
-  await mongoose.connect(process.env.MONGODB_URI);
+
+  if (!MONGODB_USERNAME || !MONGODB_PASSWORD) {
+    throw new Error(ErrorMessages.MONGODB_CREDENTIALS_NOT_SET);
+  }
+
+  if (!MONGODB_DB_NAME) {
+    throw new Error(ErrorMessages.MONGODB_DB_NAME_NOT_SET);
+  }
+
+  if (!MONGODB_TLS_CA_FILE) {
+    throw new Error(ErrorMessages.MONGODB_TLS_CONFIG_INVALID);
+  }
+
+  const tlsOptions: mongoose.ConnectOptions = {
+    tls: true,
+    tlsCAFile: MONGODB_TLS_CA_FILE,
+    tlsAllowInvalidCertificates: false
+  };
+
+  if (MONGODB_TLS_CERT_KEY_FILE) {
+    tlsOptions.tlsCertificateKeyFile = MONGODB_TLS_CERT_KEY_FILE;
+  }
+
+  await mongoose.connect(MONGODB_URI, {
+    user: MONGODB_USERNAME,
+    pass: MONGODB_PASSWORD,
+    dbName: MONGODB_DB_NAME,
+    authSource: MONGODB_AUTH_SOURCE ?? MONGODB_DB_NAME,
+    retryWrites: true,
+    w: "majority",
+    readPreference: "primary",
+    ...tlsOptions
+  });
 };

--- a/entities/ErrorMessages.ts
+++ b/entities/ErrorMessages.ts
@@ -1,5 +1,8 @@
 export enum ErrorMessages {
   MONGODB_URI_NOT_SET = "MONGODB_URI is not set. Please set it in your .env file",
+  MONGODB_CREDENTIALS_NOT_SET = "MongoDB credentials are not set. Please provide MONGODB_USERNAME and MONGODB_PASSWORD in your environment",
+  MONGODB_DB_NAME_NOT_SET = "MongoDB database name is not set. Please provide MONGODB_DB_NAME in your environment",
+  MONGODB_TLS_CONFIG_INVALID = "MongoDB TLS configuration is incomplete. Please provide MONGODB_TLS_CA_FILE (and related TLS parameters if required)",
   TELEGRAM_BOT_TOKEN_NOT_SET = "BOT_TOKEN is not set. Please set it in your .env file",
   WHATSAPP_ENV_NOT_SET = "WHATSAPP_ENV variables are not set. Please set it in your .env file",
   SIGNAL_ENV_NOT_SET = "SIGNAL_ENV variables are not set. Please set it in your .env file"

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -23,6 +23,7 @@ import { markdown2WHMarkdown, splitText } from "../utils/text.utils.ts";
 import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
 import { MAIN_MENU_MESSAGE } from "../commands/default.ts";
 import Umami from "../utils/umami.ts";
+import { guardFilter, guardUpdate } from "../utils/database/queryGuard.ts";
 
 export const WHATSAPP_MESSAGE_CHAR_LIMIT = 900;
 const WHATSAPP_COOL_DOWN_DELAY_SECONDS = 6; // 1 message every 6 seconds for the same user, but we'll take 1 here
@@ -288,8 +289,8 @@ export async function sendWhatsAppMessage(
               messageApp: "WhatsApp"
             });
             await User.updateOne(
-              { messageApp: "WhatsApp", chatId: userPhoneIdStr },
-              { $set: { status: "blocked" } }
+              guardFilter({ messageApp: "WhatsApp", chatId: userPhoneIdStr }),
+              guardUpdate({ $set: { status: "blocked" } })
             );
             break;
           case 131026: // user not on WhatsApp
@@ -298,10 +299,12 @@ export async function sendWhatsAppMessage(
               event: "/user-deactivated",
               messageApp: "WhatsApp"
             });
-            await User.deleteOne({
-              messageApp: "WhatsApp",
-              chatId: userPhoneIdStr
-            });
+            await User.deleteOne(
+              guardFilter({
+                messageApp: "WhatsApp",
+                chatId: userPhoneIdStr
+              })
+            );
             break;
           default:
             console.log(resp.error);

--- a/models/Organisation.ts
+++ b/models/Organisation.ts
@@ -2,6 +2,7 @@ import { Schema as _Schema, model } from "mongoose";
 const Schema = _Schema;
 import umami from "../utils/umami.ts";
 import { IOrganisation, OrganisationModel, WikidataId } from "../types.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 
 const OrganisationSchema = new Schema<IOrganisation, OrganisationModel>(
   {
@@ -26,9 +27,11 @@ OrganisationSchema.static(
     args: { nom: string; wikidataId: WikidataId },
     lean = true
   ): Promise<IOrganisation> {
-    const query = this.findOne({
-      wikidataId: args.wikidataId.toUpperCase()
-    });
+    const query = this.findOne(
+      guardFilter({
+        wikidataId: args.wikidataId.toUpperCase()
+      })
+    );
     if (lean) query.lean();
 
     let organisation: IOrganisation | null = await query.exec();

--- a/models/People.ts
+++ b/models/People.ts
@@ -2,6 +2,7 @@ import { Schema as _Schema, model } from "mongoose";
 import { IPeople, PeopleModel } from "../types.ts";
 import { JORFSearchItem } from "../entities/JORFSearchResponse.ts";
 import umami from "../utils/umami.ts";
+import { guardFilter } from "../utils/database/queryGuard.ts";
 const Schema = _Schema;
 
 export interface LegacyPeople_V1 {
@@ -27,10 +28,12 @@ const PeopleSchema = new Schema<IPeople, PeopleModel>(
 PeopleSchema.static(
   "findOrCreate",
   async function (peopleInfo: { nom: string; prenom: string }, lean = true) {
-    const query = this.findOne({
-      nom: peopleInfo.nom,
-      prenom: peopleInfo.prenom
-    }).collation({ locale: "fr", strength: 2 });
+    const query = this.findOne(
+      guardFilter({
+        nom: peopleInfo.nom,
+        prenom: peopleInfo.prenom
+      })
+    ).collation({ locale: "fr", strength: 2 });
     if (lean) query.lean();
 
     let people: IPeople | null = await query.exec();

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -19,6 +19,7 @@ import {
   dispatchTasksToMessageApps
 } from "./notificationDispatch.ts";
 import { getSplitTextMessageSize } from "../utils/text.utils.ts";
+import { guardFilter, guardUpdate } from "../utils/database/queryGuard.ts";
 
 const DEFAULT_GROUP_SEPARATOR = "\n====================\n\n";
 
@@ -28,11 +29,11 @@ export async function notifyNameMentionUpdates(
   messageAppsOptions: ExternalMessageOptions
 ) {
   const userFollowingNames: IUser[] = await User.find(
-    {
+    guardFilter({
       "followedNames.0": { $exists: true },
       status: "active",
       messageApp: { $in: enabledApps }
-    },
+    }),
     {
       _id: 1,
       messageApp: 1,
@@ -141,8 +142,8 @@ export async function notifyNameMentionUpdates(
     );
 
     await User.updateOne(
-      { _id: user._id },
-      {
+      guardFilter({ _id: user._id }),
+      guardUpdate({
         $pull: {
           followedNames: {
             $in: [...task.updatedRecordsMap.keys()]
@@ -156,7 +157,7 @@ export async function notifyNameMentionUpdates(
             }))
           }
         }
-      }
+      })
     );
   });
 }

--- a/scripts/convertUsersV2toV3.ts
+++ b/scripts/convertUsersV2toV3.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import { mongodbConnect } from "../db.ts";
 import User from "../models/User.ts";
 import { Types } from "mongoose";
+import { guardFilter, guardUpdate } from "../utils/database/queryGuard.ts";
 
 interface oldMiniUser {
   _id: Types.ObjectId;
@@ -12,7 +13,7 @@ await (async function () {
   await mongodbConnect();
 
   const users = (await User.collection
-    .find({ chatId: { $exists: true } })
+    .find(guardFilter({ chatId: { $exists: true } }))
     .toArray()) as oldMiniUser[];
 
   let updatedCount = 0;
@@ -21,8 +22,8 @@ await (async function () {
     const chatId = user.chatId;
 
     await User.collection.updateOne(
-      { _id: user._id },
-      { $set: { chatId: String(chatId), schemaVersion: 3 } }
+      guardFilter({ _id: user._id }),
+      guardUpdate({ $set: { chatId: String(chatId), schemaVersion: 3 } })
     );
     updatedCount += 1;
   }

--- a/utils/database/queryGuard.ts
+++ b/utils/database/queryGuard.ts
@@ -1,0 +1,108 @@
+type PlainRecord = Record<string, unknown>;
+
+const FILTER_OPERATORS = new Set<string>([
+  "$and",
+  "$or",
+  "$nor",
+  "$eq",
+  "$ne",
+  "$in",
+  "$nin",
+  "$gt",
+  "$gte",
+  "$lt",
+  "$lte",
+  "$exists",
+  "$regex",
+  "$elemMatch",
+  "$size",
+  "$all",
+  "$not",
+  "$type",
+  "$geoWithin",
+  "$geoIntersects",
+  "$near",
+  "$nearSphere"
+]);
+
+const UPDATE_OPERATORS = new Set<string>([
+  "$set",
+  "$setOnInsert",
+  "$unset",
+  "$inc",
+  "$mul",
+  "$min",
+  "$max",
+  "$rename",
+  "$currentDate",
+  "$addToSet",
+  "$push",
+  "$pull",
+  "$pullAll",
+  "$pop",
+  "$bit",
+  "$each",
+  "$position",
+  "$slice",
+  "$sort"
+]);
+
+const DEFAULT_ALLOWED_KEYS = new Set<string>([
+  ...FILTER_OPERATORS,
+  ...UPDATE_OPERATORS
+]);
+
+const isPlainObject = (value: unknown): value is PlainRecord => {
+  if (value === null || typeof value !== "object") return false;
+  if (value instanceof Date || value instanceof RegExp) return false;
+  return Object.getPrototypeOf(value) === Object.prototype;
+};
+
+const assertAllowedOperators = (
+  value: unknown,
+  allowedOperators: Set<string>,
+  path: string
+): void => {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertAllowedOperators(item, allowedOperators, `${path}[${index}]`)
+    );
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (key.startsWith("$") && !allowedOperators.has(key)) {
+      throw new Error(`Disallowed MongoDB operator "${key}" detected at ${path}`);
+    }
+    assertAllowedOperators(nested, allowedOperators, `${path}.${key}`);
+  }
+};
+
+export const guardFilter = <T extends PlainRecord | unknown>(filter: T): T => {
+  assertAllowedOperators(filter, FILTER_OPERATORS, "filter");
+  return filter;
+};
+
+export const guardUpdate = <T extends PlainRecord | unknown>(update: T): T => {
+  assertAllowedOperators(update, DEFAULT_ALLOWED_KEYS, "update");
+  return update;
+};
+
+export const guardPipeline = <T extends unknown[]>(pipeline: T): T => {
+  pipeline.forEach((stage, index) =>
+    assertAllowedOperators(stage, DEFAULT_ALLOWED_KEYS, `pipeline[${index}]`)
+  );
+  return pipeline;
+};
+
+export const guardAggregationStage = <T>(stage: T): T => {
+  assertAllowedOperators(stage, DEFAULT_ALLOWED_KEYS, "pipelineStage");
+  return stage;
+};
+
+export const allowedFilterOperators = FILTER_OPERATORS;
+export const allowedUpdateOperators = UPDATE_OPERATORS;


### PR DESCRIPTION
## Summary
- enforce TLS and credential validation when connecting to MongoDB and enable global sanitize/strict query options
- add a reusable query guard utility and apply it across commands, notifications, apps, and scripts that build raw Mongo filters or updates
- update scripts and runtime helpers to reuse the secure connection path and guarded filters

## Testing
- npm test *(fails: jest not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918cc63d1fc832d88ea4a4bd3bbb811)