### PR TITLE
Add text alert command and update followed metadata schema

### DIFF
--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -30,6 +30,7 @@ import {
 import { buildInfoCommand } from "./help.ts";
 import { exportCommand, importCommand } from "./importExport.ts";
 import { sanitizeUserInput } from "../utils/text.utils.ts";
+import { textAlertCommand } from "./textAlert.ts";
 
 export async function processMessage(
   session: ISession,
@@ -79,6 +80,10 @@ export const commands: CommandType[] = [
   {
     regex: /^\/start$|^Bonjour /i,
     action: startCommand
+  },
+  {
+    regex: /^\/textAlert/i,
+    action: textAlertCommand
   },
   {
     regex: /^Rechercher$|^Recherche$/i,

--- a/commands/followOrganisation.ts
+++ b/commands/followOrganisation.ts
@@ -1,6 +1,6 @@
 import Organisation from "../models/Organisation.ts";
 import User from "../models/User.ts";
-import { IOrganisation, ISession, IUser, WikidataId } from "../types.ts";
+import { IOrganisation, ISession, WikidataId } from "../types.ts";
 import { parseIntAnswers } from "../utils/text.utils.ts";
 import {
   getJORFSearchLinkOrganisation,
@@ -12,13 +12,6 @@ import {
   KEYBOARD_KEYS
 } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
-
-const isOrganisationAlreadyFollowed = (
-  user: IUser,
-  wikidataId: WikidataId
-): boolean => {
-  return user.followedOrganisations.some((o) => o.wikidataId === wikidataId);
-};
 
 const FULL_COMMAND_PROMPT = `\n\nFormat:\n*RechercherO Nom de l'organisation*\nou\n*RechercherO WikidataId de l'organisation*`;
 
@@ -153,7 +146,7 @@ async function handleSingleOrganisationResult(
 
   if (
     session.user &&
-    isOrganisationAlreadyFollowed(session.user, organisation.wikidataId)
+    session.user.checkFollowedOrganisation(organisation.wikidataId)
   ) {
     text += `\n\nVous suivez déjà *${organisation.nom}* ✅`;
     await session.sendMessage(text, { keyboard: ORGANISATION_SEARCH_KEYBOARD });
@@ -210,7 +203,7 @@ async function handleMultipleOrganisationResults(
 
     if (
       session.user != undefined &&
-      isOrganisationAlreadyFollowed(session.user, organisation_k.wikidataId)
+      session.user.checkFollowedOrganisation(organisation_k.wikidataId)
     )
       text += ` - Suivi ✅`;
 
@@ -384,23 +377,33 @@ export const followOrganisationsFromWikidataIdStr = async (
 
     session.user ??= await User.findOrCreate(session);
 
-    for (const org of orgResults) {
-      // Don't call JORF if the organisation is already followed
-      if (!isOrganisationAlreadyFollowed(session.user, org.wikidataId))
-        session.user.followedOrganisations.push({
-          wikidataId: org.wikidataId,
-          lastUpdate: new Date()
-        });
-    }
+    const addedOrganisations: IOrganisation[] = [];
+    const alreadyFollowedOrganisations: IOrganisation[] = [];
 
-    await session.user.save();
+    for (const org of orgResults) {
+      if (await session.user.addFollowedOrganisation(org)) {
+        addedOrganisations.push(org);
+      } else {
+        alreadyFollowedOrganisations.push(org);
+      }
+    }
 
     let text = "";
 
-    if (orgResults.length == 1)
-      text += `Vous suivez désormais *${orgResults[0].nom}* (${orgResults[0].wikidataId}) ✅`;
-    else
-      text += `Vous suivez désormais les organisations: ✅\n${orgResults
+    if (addedOrganisations.length == 1)
+      text += `Vous suivez désormais *${addedOrganisations[0].nom}* (${addedOrganisations[0].wikidataId}) ✅`;
+    else if (addedOrganisations.length > 1)
+      text += `Vous suivez désormais les organisations: ✅\n${addedOrganisations
+        .map((org) => `\n   - *${org.nom}* (${org.wikidataId})`)
+        .join("\n")}`;
+
+    if (addedOrganisations.length > 0 && alreadyFollowedOrganisations.length > 0)
+      text += "\n\n";
+
+    if (alreadyFollowedOrganisations.length === 1)
+      text += `Vous suivez déjà *${alreadyFollowedOrganisations[0].nom}* (${alreadyFollowedOrganisations[0].wikidataId}) ✅`;
+    else if (alreadyFollowedOrganisations.length > 1)
+      text += `Vous suivez déjà les organisations: ✅\n${alreadyFollowedOrganisations
         .map((org) => `\n   - *${org.nom}* (${org.wikidataId})`)
         .join("\n")}`;
 

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -506,36 +506,24 @@ export const unfollowFromStr = async (
       }
     }
 
-    session.user.followedPeople = session.user.followedPeople.filter(
-      (people) =>
-        !unfollowedPeopleId
-          .map((id) => id.toString())
-          .includes(people.peopleId.toString())
+    const namesToRemove = unfollowedNamesIdx.map(
+      (idx) => session.user?.followedNames[idx]
     );
 
-    session.user.followedNames = session.user.followedNames.filter(
-      (_value, idx) => !unfollowedNamesIdx.includes(idx)
-    );
+    for (const peopleId of unfollowedPeopleId)
+      await session.user.removeFollowedPeople(peopleId);
 
-    session.user.followedMeta = session.user.followedMeta.filter((meta) => {
-      return !unfollowedMeta
-        .map((u) => u.alertString.trim().toLowerCase())
-        .includes(meta.alertString.trim().toLowerCase());
-    });
+    for (const name of namesToRemove)
+      if (name !== undefined) await session.user.removeFollowedName(name);
 
-    session.user.followedOrganisations =
-      session.user.followedOrganisations.filter(
-        (org) =>
-          !unfollowedOrganisations
-            .map((o) => o.wikidataId)
-            .includes(org.wikidataId)
-      );
+    for (const meta of unfollowedMeta)
+      await session.user.removeFollowedAlertString(meta.alertString);
 
-    session.user.followedFunctions = session.user.followedFunctions.filter(
-      (tag) => !unfollowedFunctions.includes(tag.functionTag)
-    );
+    for (const org of unfollowedOrganisations)
+      await session.user.removeFollowedOrganisation(org.wikidataId);
 
-    await session.user.save();
+    for (const fct of unfollowedFunctions)
+      await session.user.removeFollowedFunction(fct);
 
     // Delete the user if it doesn't follow anything any more
     if (session.user.followsNothing()) {

--- a/commands/textAlert.ts
+++ b/commands/textAlert.ts
@@ -1,0 +1,58 @@
+import User from "../models/User.ts";
+import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { ISession } from "../types.ts";
+import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
+
+const TEXT_ALERT_PROMPT =
+  "Quel texte souhaitez-vous surveiller ? Renseignez un mot ou une expression.";
+
+async function askTextAlertQuestion(session: ISession): Promise<void> {
+  await askFollowUpQuestion(session, TEXT_ALERT_PROMPT, handleTextAlertAnswer, {
+    messageOptions: { keyboard: [[KEYBOARD_KEYS.MAIN_MENU.key]] }
+  });
+}
+
+async function handleTextAlertAnswer(
+  session: ISession,
+  answer: string
+): Promise<boolean> {
+  const trimmedAnswer = answer.trim();
+
+  if (trimmedAnswer.length === 0) {
+    await session.sendMessage(
+      "Votre texte n'a pas été reconnu. Merci d'entrer un mot ou une expression.",
+      { keyboard: [[KEYBOARD_KEYS.MAIN_MENU.key]] }
+    );
+    await askTextAlertQuestion(session);
+    return true;
+  }
+
+  if (trimmedAnswer.startsWith("/")) {
+    return false;
+  }
+
+  session.user ??= await User.findOrCreate(session);
+
+  const wasAdded = await session.user.addFollowedAlertString(trimmedAnswer);
+  const responseText = wasAdded
+    ? `Alerte enregistrée pour « ${trimmedAnswer} » ✅`
+    : `Vous suivez déjà une alerte pour « ${trimmedAnswer} ». ✅`;
+
+  await session.sendMessage(responseText, {
+    keyboard: [[KEYBOARD_KEYS.MAIN_MENU.key]]
+  });
+
+  return true;
+}
+
+export const textAlertCommand = async (session: ISession): Promise<void> => {
+  await session.log({ event: "/text-alert" });
+  try {
+    await session.sendTypingAction();
+    await askTextAlertQuestion(session);
+  } catch (error) {
+    console.log(error);
+    await session.log({ event: "/console-log" });
+  }
+};
+

--- a/models/LegacyUser.ts
+++ b/models/LegacyUser.ts
@@ -24,7 +24,7 @@ export interface LegacyRawUser_V2 extends Document {
     lastUpdate: Date;
   }[];
   followedMeta: {
-    metaType: string;
+    alertString: string;
     lastUpdate: Date;
   }[];
 

--- a/models/User.ts
+++ b/models/User.ts
@@ -79,10 +79,9 @@ const UserSchema = new Schema<IUser, UserModel>(
       default: []
     },
     followedMeta: {
-      // Placeholder before implementation
       type: [
         {
-          metaType: {
+          alertString: {
             type: String
           },
           lastUpdate: {
@@ -305,6 +304,43 @@ UserSchema.method(
     return this.followedNames.some((elem) => {
       return elem.toUpperCase() === nameClean.toUpperCase();
     });
+  }
+);
+
+UserSchema.method(
+  "checkFollowedAlertString",
+  function checkFollowedAlertString(this: IUser, alertString: string): boolean {
+    const normalizedAlertString = alertString.trim().toLowerCase();
+    return this.followedMeta.some((elem) => {
+      return (
+        elem.alertString?.trim().toLowerCase() === normalizedAlertString
+      );
+    });
+  }
+);
+
+UserSchema.method(
+  "addFollowedAlertString",
+  async function addFollowedAlertString(this: IUser, alertString: string) {
+    if (this.checkFollowedAlertString(alertString)) return false;
+    this.followedMeta.push({ alertString: alertString.trim(), lastUpdate: new Date() });
+    await this.save();
+    return true;
+  }
+);
+
+UserSchema.method(
+  "removeFollowedAlertString",
+  async function removeFollowedAlertString(this: IUser, alertString: string) {
+    if (!this.checkFollowedAlertString(alertString)) return false;
+    const normalizedAlertString = alertString.trim().toLowerCase();
+    this.followedMeta = this.followedMeta.filter((elem) => {
+      return (
+        elem.alertString?.trim().toLowerCase() !== normalizedAlertString
+      );
+    });
+    await this.save();
+    return true;
   }
 );
 

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -1,0 +1,179 @@
+import {
+  ExternalMessageOptions,
+  MiniUserInfo,
+  sendMessage
+} from "../entities/Session.ts";
+import { JORFSearchPublication } from "../entities/JORFSearchResponseMeta.ts";
+import { IUser, MessageApp } from "../types.ts";
+import User from "../models/User.ts";
+import umami, { UmamiNotificationData } from "../utils/umami.ts";
+import { dateToFrenchString } from "../utils/date.utils.ts";
+import { fuzzyIncludes, getSplitTextMessageSize } from "../utils/text.utils.ts";
+import {
+  NotificationTask,
+  dispatchTasksToMessageApps
+} from "./notificationDispatch.ts";
+
+const DEFAULT_GROUP_SEPARATOR = "\n====================\n\n";
+
+export async function notifyAlertStringUpdates(
+  metaRecords: JORFSearchPublication[],
+  enabledApps: MessageApp[],
+  messageAppsOptions: ExternalMessageOptions
+) {
+  if (metaRecords.length === 0) return;
+
+  const usersFollowingAlerts: IUser[] = await User.find(
+    {
+      "followedMeta.0": { $exists: true },
+      status: "active",
+      messageApp: { $in: enabledApps }
+    },
+    {
+      _id: 1,
+      messageApp: 1,
+      chatId: 1,
+      roomId: 1,
+      followedMeta: 1
+    }
+  ).lean();
+
+  if (usersFollowingAlerts.length === 0) return;
+
+  const now = new Date();
+  const userUpdateTasks: NotificationTask<string, JORFSearchPublication>[] = [];
+
+  for (const user of usersFollowingAlerts) {
+    const newAlertUpdates = new Map<string, JORFSearchPublication[]>();
+
+    for (const follow of user.followedMeta) {
+      if (!follow.alertString) continue;
+      const updatesForAlert = metaRecords.filter((record) =>
+        fuzzyIncludes(record.title, follow.alertString)
+      );
+
+      const lastUpdate = follow.lastUpdate ?? new Date(0);
+      const dateFilteredUpdates = updatesForAlert.filter((record) => {
+        const publicationDate = record.date ? new Date(record.date) : null;
+        return publicationDate ? publicationDate.getTime() > lastUpdate.getTime() : true;
+      });
+
+      if (dateFilteredUpdates.length > 0) {
+        newAlertUpdates.set(follow.alertString, dateFilteredUpdates);
+      }
+    }
+
+    let totalUserRecordsCount = 0;
+    newAlertUpdates.forEach((items) => {
+      totalUserRecordsCount += items.length;
+    });
+
+    if (totalUserRecordsCount > 0) {
+      userUpdateTasks.push({
+        userId: user._id,
+        userInfo: {
+          messageApp: user.messageApp,
+          chatId: user.chatId,
+          roomId: user.roomId
+        },
+        updatedRecordsMap: newAlertUpdates,
+        recordCount: totalUserRecordsCount
+      });
+    }
+  }
+
+  if (userUpdateTasks.length === 0) return;
+
+  await dispatchTasksToMessageApps<string, JORFSearchPublication>(
+    userUpdateTasks,
+    async (task) => {
+      const messageSent = await sendAlertStringUpdate(
+        task.userInfo,
+        task.updatedRecordsMap,
+        messageAppsOptions
+      );
+
+      if (!messageSent) return;
+
+      await User.updateOne(
+        { _id: task.userId },
+        {
+          $set: {
+            "followedMeta.$[elem].lastUpdate": now
+          }
+        },
+        {
+          arrayFilters: [
+            {
+              "elem.alertString": { $in: [...task.updatedRecordsMap.keys()] }
+            }
+          ]
+        }
+      );
+    }
+  );
+}
+
+async function sendAlertStringUpdate(
+  userInfo: MiniUserInfo,
+  updatedRecordMap: Map<string, JORFSearchPublication[]>,
+  messageAppsOptions: ExternalMessageOptions
+): Promise<boolean> {
+  if (updatedRecordMap.size === 0) return true;
+
+  const pluralHandler = updatedRecordMap.size > 1 ? "s" : "";
+  const markdownLinkEnabled = userInfo.messageApp !== "WhatsApp";
+
+  let notificationText = `📢 Nouvelle${pluralHandler} alerte${pluralHandler} texte :\n\n`;
+
+  const keys = Array.from(updatedRecordMap.keys());
+  const lastKey = keys[keys.length - 1];
+
+  for (const alert of updatedRecordMap.keys()) {
+    const updates = updatedRecordMap.get(alert);
+    if (!updates || updates.length === 0) continue;
+
+    notificationText += `🔔 *${alert}*\n`;
+
+    for (const record of updates) {
+      const publicationLink = `https://bodata.steinertriples.ch/${record.id}/redirect`;
+      const dateString = record.date ? dateToFrenchString(record.date) : undefined;
+
+      notificationText += `• ${record.title}\n`;
+      if (dateString) notificationText += `🗓️ ${dateString}\n`;
+      notificationText += markdownLinkEnabled
+        ? `🔗 [Lien vers le texte](${publicationLink})\n\n`
+        : `🔗 ${publicationLink}\n\n`;
+    }
+
+    if (alert !== lastKey) notificationText += DEFAULT_GROUP_SEPARATOR;
+  }
+
+  const messageAppsOptionsApp = {
+    ...messageAppsOptions,
+    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+  };
+
+  const messageSent = await sendMessage(
+    userInfo,
+    notificationText,
+    messageAppsOptionsApp
+  );
+  if (!messageSent) return false;
+
+  const notifData: UmamiNotificationData = {
+    message_nb: getSplitTextMessageSize(notificationText, userInfo.messageApp),
+    updated_follows_nb: updatedRecordMap.size,
+    total_records_nb: updatedRecordMap
+      .values()
+      .reduce((total: number, value) => total + value.length, 0)
+  };
+
+  await umami.log({
+    event: "/notification-update-meta",
+    messageApp: userInfo.messageApp,
+    notificationData: notifData
+  });
+
+  return true;
+}

--- a/notifications/notificationDispatch.ts
+++ b/notifications/notificationDispatch.ts
@@ -12,16 +12,16 @@ import { MiniUserInfo } from "../entities/Session.ts";
  * Schedules the sendMessage to respect per-app throttling rules.
  * Returns the promise representing the delivery attempt.
  */
-export interface NotificationTask<T> {
+export interface NotificationTask<T, R = JORFSearchItem> {
   userId: Types.ObjectId;
   userInfo: MiniUserInfo;
-  updatedRecordsMap: Map<T, JORFSearchItem[]>;
+  updatedRecordsMap: Map<T, R[]>;
   recordCount: number;
 }
 
-export async function dispatchTasksToMessageApps<T>(
-  taskList: NotificationTask<T>[],
-  taskFunction: (task: NotificationTask<T>) => Promise<void>
+export async function dispatchTasksToMessageApps<T, R = JORFSearchItem>(
+  taskList: NotificationTask<T, R>[],
+  taskFunction: (task: NotificationTask<T, R>) => Promise<void>
 ): Promise<void> {
   taskList.sort((a, b) => b.recordCount - a.recordCount);
 
@@ -39,7 +39,7 @@ export async function dispatchTasksToMessageApps<T>(
   );
   concurrencyLimitByMessageApp.set("Signal", SIGNAL_API_SENDING_CONCURRENCY);
 
-  const tasksByMessageApp = new Map<MessageApp, NotificationTask<T>[]>();
+  const tasksByMessageApp = new Map<MessageApp, NotificationTask<T, R>[]>();
   taskList.forEach((task) => {
     tasksByMessageApp.set(
       task.userInfo.messageApp,

--- a/tests/02.user.test.ts
+++ b/tests/02.user.test.ts
@@ -27,6 +27,10 @@ const exampleFollowedOrganisations: IUser["followedOrganisations"] = [
   { wikidataId: "987654321", lastUpdate: new Date() }
 ];
 
+const exampleFollowedMeta: IUser["followedMeta"] = [
+  { alertString: "budget", lastUpdate: new Date() }
+];
+
 const MockTelegramSession = {
   chatId: userMockChatId,
   messageApp: "Telegram",
@@ -74,7 +78,7 @@ const currentUserData_withFollows = {
   followedFunctions: exampleCurrentFollowedFunctions,
   followedNames: exampleFollowedNames,
   followedOrganisations: exampleFollowedOrganisations,
-  followedMeta: [],
+  followedMeta: exampleFollowedMeta,
   lastInteractionDay: Date.now(),
   lastInteractionMonth: Date.now(),
   lastInteractionWeek: Date.now(),
@@ -117,6 +121,11 @@ describe("User Model Test Suite", () => {
             wikidataId: o.wikidataId,
             lastUpdate: o.lastUpdate
           }));
+
+        userFromDBLean.followedMeta = userFromDBLean.followedMeta.map((meta) => ({
+          alertString: meta.alertString,
+          lastUpdate: meta.lastUpdate
+        }));
 
         userFromDBLean.followedFunctions = userFromDBLean.followedFunctions.map(
           (f) => ({

--- a/types.d.ts
+++ b/types.d.ts
@@ -55,7 +55,7 @@ export interface IUser {
     lastUpdate: Date;
   }[];
   followedMeta: {
-    metaType: string;
+    alertString: string;
     lastUpdate: Date;
   }[];
 
@@ -88,9 +88,12 @@ export interface IUser {
   addFollowedPeopleBulk: (arg0: IPeople[]) => Promise<boolean>;
   addFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   addFollowedName: (arg0: string) => Promise<boolean>;
+  addFollowedAlertString: (arg0: string) => Promise<boolean>;
   removeFollowedPeople: (arg0: IPeople) => Promise<boolean>;
   removeFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   removeFollowedName: (arg0: string) => Promise<boolean>;
+  removeFollowedAlertString: (arg0: string) => Promise<boolean>;
+  checkFollowedAlertString: (arg0: string) => boolean;
   followsNothing: () => boolean;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -81,18 +81,23 @@ export interface IUser {
 
   updateInteractionMetrics: () => Promise<void>;
 
-  checkFollowedPeople: (arg0: IPeople) => boolean;
+  checkFollowedPeople: (arg0: IPeople | Types.ObjectId) => boolean;
   checkFollowedFunction: (arg0: FunctionTags) => boolean;
   checkFollowedName: (arg0: string) => boolean;
+  checkFollowedOrganisation: (arg0: IOrganisation | WikidataId) => boolean;
   addFollowedPeople: (arg0: IPeople) => Promise<boolean>;
   addFollowedPeopleBulk: (arg0: IPeople[]) => Promise<boolean>;
   addFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   addFollowedName: (arg0: string) => Promise<boolean>;
   addFollowedAlertString: (arg0: string) => Promise<boolean>;
-  removeFollowedPeople: (arg0: IPeople) => Promise<boolean>;
+  addFollowedOrganisation: (arg0: IOrganisation | WikidataId) => Promise<boolean>;
+  removeFollowedPeople: (arg0: IPeople | Types.ObjectId) => Promise<boolean>;
   removeFollowedFunction: (arg0: FunctionTags) => Promise<boolean>;
   removeFollowedName: (arg0: string) => Promise<boolean>;
   removeFollowedAlertString: (arg0: string) => Promise<boolean>;
+  removeFollowedOrganisation: (
+    arg0: IOrganisation | WikidataId
+  ) => Promise<boolean>;
   checkFollowedAlertString: (arg0: string) => boolean;
   followsNothing: () => boolean;
 }


### PR DESCRIPTION
## Summary
- rename `followedMeta` entries to use `alertString` and add helpers for managing text alerts
- introduce a `/textAlert` flow that collects alert text from the user and stores it with a timestamp
- display and remove saved text alerts from the `/list` and unfollow flows

## Testing
- npm test -- 02.user.test.ts *(fails: jest/dev dependencies unavailable because npm install is blocked in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f627bf5d4832d8051df8c8742aa0d)