### PR TITLE
Handle reference detection in follow flow

### DIFF
--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -12,7 +12,12 @@ import {
   searchCommand,
   searchPersonHistory
 } from "./search.ts";
-import { enaCommand, promosCommand, suivreFromJOReference } from "./ena.ts";
+import {
+  enaCommand,
+  followReferenceFromStr,
+  promosCommand,
+  suivreFromJOReference
+} from "./ena.ts";
 import { statsCommand } from "./stats.ts";
 import { defaultCommand } from "./default.ts";
 import { startCommand } from "./start.ts";
@@ -104,7 +109,7 @@ export const commands: CommandType[] = [
   {
     regex:
       /^SuivreR|^SuiviR|^Suivre R |^Suivi R |^Suivre R$|^Suivi R$|^Suivre à partir d'une référence JORF\/BO/i,
-    action: suivreFromJOReference
+    action: followReferenceFromStr
   },
   {
     regex: /^SuivreN|^SuiviN/i,

--- a/commands/search.ts
+++ b/commands/search.ts
@@ -15,6 +15,7 @@ import {
   KEYBOARD_KEYS
 } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { followReferenceFromStr } from "./ena.ts";
 
 const isPersonAlreadyFollowed = (
   person: IPeople,
@@ -330,14 +331,19 @@ export const followCommand = async (
 
     const msgSplit = msg.split(" ");
 
+    const personName = msgSplit.slice(1).join(" ");
+
+    if (/\d/.test(personName)) {
+      await followReferenceFromStr(session, msg);
+      return;
+    }
+
     if (msgSplit.length < 3) {
       await session.sendMessage(
         "Saisie incorrecte. Veuillez réessayer:\nFormat : *Suivre Prénom Nom*"
       );
       return;
     }
-
-    const personName = msgSplit.slice(1).join(" ");
 
     await session.sendTypingAction();
 


### PR DESCRIPTION
## Summary
- add shared helper to process reference-based follow requests
- route follow commands that contain numbers to the reference flow and reuse it for reference shortcuts
- keep existing person follow behaviour for non-reference inputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693060996fec832daf4ed08d104833e0)