### PR TITLE
Remove redundant Umami error logs

### DIFF
--- a/apps/matrixApp.ts
+++ b/apps/matrixApp.ts
@@ -14,6 +14,7 @@ import { startDailyNotificationJobs } from "../notifications/notificationSchedul
 import User from "../models/User.ts";
 import { IUser } from "../types";
 import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
+import { logError } from "../utils/debugLogger.ts";
 const { MATRIX_HOME_URL, MATRIX_BOT_TOKEN, MATRIX_BOT_TYPE } = process.env;
 if (
   MATRIX_HOME_URL == undefined ||
@@ -261,8 +262,7 @@ function handleCommand(roomId: string, event: MatrixRoomEvent) {
 
       await processMessage(matrixSession, msgText);
     } catch (error) {
-      console.log(error);
-      await umami.log({ event: "/console-log", messageApp: matrixApp });
+      await logError(matrixApp, "Error processing command", error);
     }
   })();
 }

--- a/apps/signalApp.ts
+++ b/apps/signalApp.ts
@@ -6,6 +6,7 @@ import { SignalSession } from "../entities/SignalSession.ts";
 import { processMessage } from "../commands/Commands.ts";
 import umami from "../utils/umami.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
+import { logError } from "../utils/debugLogger.ts";
 
 const { SIGNAL_PHONE_NUMBER, SIGNAL_BAT_PATH } = process.env;
 
@@ -61,7 +62,7 @@ await (async () => {
 
           await processMessage(signalSession, msgText);
         } catch (error) {
-          console.error("Signal: Error processing command:", error);
+          await logError("Signal", "Error processing command", error);
         }
       })();
     });
@@ -72,7 +73,6 @@ await (async () => {
     // Graceful shutdown
     //await signal.gracefulShutdown();
   } catch (error) {
-    console.log(error);
-    await umami.log({ event: "/console-log", messageApp: "Signal" });
+    await logError("Signal", "Failed to start Signal app", error);
   }
 })();

--- a/apps/telegramApp.ts
+++ b/apps/telegramApp.ts
@@ -6,6 +6,7 @@ import { TelegramSession } from "../entities/TelegramSession.ts";
 import { processMessage } from "../commands/Commands.ts";
 import umami from "../utils/umami.ts";
 import { startDailyNotificationJobs } from "../notifications/notificationScheduler.ts";
+import { logError } from "../utils/debugLogger.ts";
 
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 if (TELEGRAM_BOT_TOKEN === undefined) {
@@ -39,8 +40,7 @@ await (async () => {
 
       await processMessage(tgSession, ctx.message.text);
     } catch (error) {
-      console.error("Telegram: Error processing command:", error);
-      await umami.log({ event: "/console-log", messageApp: "Telegram" });
+      await logError("Telegram", "Error processing command", error);
     }
   });
 

--- a/commands/textAlert.ts
+++ b/commands/textAlert.ts
@@ -7,6 +7,7 @@ import { fuzzyIncludes } from "../utils/text.utils.ts";
 import { getJORFTextLink } from "../utils/JORFSearch.utils.ts";
 import { JORFSearchPublication } from "../entities/JORFSearchResponseMeta.ts";
 import umami from "../utils/umami.ts";
+import { logError } from "../utils/debugLogger.ts";
 
 const TEXT_ALERT_PROMPT =
   "Quel texte souhaitez-vous rechercher ? Renseignez un mot ou une expression.";
@@ -248,8 +249,11 @@ async function getRecentPublications(
 
     return await inflightRefresh;
   } catch (error) {
-    console.error("Failed to recent publications cache", error);
-    await umami.log({ event: "/console-log", messageApp });
+    await logError(
+      messageApp,
+      "Failed to refresh recent publications cache",
+      error
+    );
   }
   return null;
 }

--- a/notifications/notificationScheduler.ts
+++ b/notifications/notificationScheduler.ts
@@ -2,8 +2,8 @@ import "dotenv/config";
 import { MessageApp } from "../types.ts";
 import { runNotificationProcess } from "./runNotificationProcess.ts";
 import { ExternalMessageOptions } from "../entities/Session.ts";
-import { session } from "telegraf";
 import umami from "../utils/umami.ts";
+import { logError, logWarning } from "../utils/debugLogger.ts";
 
 interface DailyTime {
   hour: number;
@@ -64,8 +64,13 @@ export function startDailyNotificationJobs(
     setTimeout(() => {
       void (async () => {
         if (running) {
-          console.warn(
-            `${appsToString}: notification process is still running when the next schedule fired. Skipping this cycle.`
+          await Promise.all(
+            messageApps.map((app) =>
+              logWarning(
+                app,
+                `${app}: notification process is still running when the next schedule fired. Skipping this cycle.`
+              )
+            )
           );
           for (const app of messageApps) {
             await umami.log({ event: `/console-log`, messageApp: app });
@@ -78,13 +83,15 @@ export function startDailyNotificationJobs(
         try {
           await runNotificationProcess(messageApps, messageOptions);
         } catch (error) {
-          console.error(
-            `${appsToString}: error during notification process`,
-            error
+          await Promise.all(
+            messageApps.map((app) =>
+              logError(
+                app,
+                `${app}: error during notification process`,
+                error
+              )
+            )
           );
-          for (const app of messageApps) {
-            await umami.log({ event: `/console-log`, messageApp: app });
-          }
         } finally {
           running = false;
           scheduleNextRun();

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -1,0 +1,81 @@
+import axios from "axios";
+import { MessageApp } from "../types.ts";
+import umami from "./umami.ts";
+
+type LogLevel = "warning" | "error";
+
+const DEBUG_CHAT_ID = process.env.DEBUG_BOT;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+const formatError = (error: unknown): string | null => {
+  if (error == null) return null;
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}${error.stack ? `\n${error.stack}` : ""}`;
+  }
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch (stringifyError) {
+    return `Unknown error (could not serialize): ${String(stringifyError)}`;
+  }
+};
+
+const sendTelegramDebugMessage = async (text: string): Promise<void> => {
+  if (DEBUG_CHAT_ID == null || TELEGRAM_BOT_TOKEN == null) return;
+
+  const endpoint = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+
+  try {
+    await axios.post(endpoint, {
+      chat_id: DEBUG_CHAT_ID,
+      text
+    });
+  } catch (sendError) {
+    console.error("Failed to send debug log to Telegram:", sendError);
+  }
+};
+
+const logToConsole = (level: LogLevel, message: string, error?: unknown): void => {
+  if (level === "warning") {
+    console.warn(message);
+    if (error) console.warn(error);
+  } else {
+    console.error(message);
+    if (error) console.error(error);
+  }
+};
+
+const buildLogMessage = (
+  level: LogLevel,
+  messageApp: MessageApp,
+  message: string,
+  error?: unknown
+): string => {
+  const levelEmoji = level === "error" ? "❌" : "⚠️";
+  const errorText = formatError(error);
+  return [
+    `${levelEmoji} [${messageApp}] ${message}`,
+    errorText != null ? `Details:\n${errorText}` : null
+  ]
+    .filter((part): part is string => part != null)
+    .join("\n");
+};
+
+export const logWarning = async (
+  messageApp: MessageApp,
+  message: string,
+  error?: unknown
+): Promise<void> => {
+  logToConsole("warning", message, error);
+  await sendTelegramDebugMessage(buildLogMessage("warning", messageApp, message, error));
+};
+
+export const logError = async (
+  messageApp: MessageApp,
+  message: string,
+  error?: unknown
+): Promise<void> => {
+  logToConsole("error", message, error);
+  await umami.log({ event: "/console-log", messageApp });
+  await sendTelegramDebugMessage(buildLogMessage("error", messageApp, message, error));
+};


### PR DESCRIPTION
## Summary
- remove duplicate Umami console log events next to logError now that logError sends them
- keep existing warning instrumentation unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931a0b397ac832d8dd686539ee1407f)