### PR TITLE
Clean up follow data when deleting users

### DIFF
--- a/commands/deleteProfile.ts
+++ b/commands/deleteProfile.ts
@@ -1,7 +1,7 @@
-import User from "../models/User.ts";
 import { ISession } from "../types.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
 import { KEYBOARD_KEYS } from "../entities/Keyboard.ts";
+import { deleteUserAndCleanup } from "../utils/userDeletion.utils.ts";
 
 const DELETE_PROFILE_CONFIRMATION_PROMPT =
   "*Vous êtes sur le point de supprimer votre profil JOÉL*, comprenant l'ensemble de vos contacts, fonctions et organisations suivis.\n" +
@@ -42,9 +42,7 @@ async function handleDeleteProfileAnswer(
   }
 
   if (trimmedAnswer === "SUPPRIMER MON COMPTE") {
-    await User.deleteOne({
-      _id: session.user._id
-    });
+    await deleteUserAndCleanup(session.user);
     session.user = null;
     await session.sendMessage(
       `🗑 Votre profil a bien été supprimé ! 👋\\splitUn profil vierge sera créé lors de l'ajout du prochain suivi ⚠️`

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/JORFSearch.utils.ts";
 import { Keyboard, KEYBOARD_KEYS } from "../entities/Keyboard.ts";
 import { askFollowUpQuestion } from "../entities/FollowUpManager.ts";
+import { deleteEntitiesWithNoFollowers } from "../utils/userDeletion.utils.ts";
 
 export interface UserFollows {
   functions: FunctionTags[];
@@ -35,29 +36,6 @@ export function getUserFollowsTotal(userFollows: UserFollows): number {
     userFollows.peopleAndNames.length +
     userFollows.meta.length
   );
-}
-
-async function deleteEntitiesWithNoFollowers(
-  peopleIds: Types.ObjectId[],
-  organisationIds: string[]
-): Promise<void> {
-  for (const peopleId of peopleIds) {
-    const isStillFollowed = await User.exists({
-      "followedPeople.peopleId": peopleId
-    });
-    if (isStillFollowed === null) {
-      await People.deleteOne({ _id: peopleId });
-    }
-  }
-
-  for (const wikidataId of organisationIds) {
-    const isStillFollowed = await User.exists({
-      "followedOrganisations.wikidataId": wikidataId
-    });
-    if (isStillFollowed === null) {
-      await Organisation.deleteOne({ wikidataId });
-    }
-  }
 }
 
 interface BuildFollowsListMessageOptions {

--- a/entities/TelegramSession.ts
+++ b/entities/TelegramSession.ts
@@ -8,6 +8,7 @@ import {
 } from "./Session.ts";
 import umami, { UmamiEvent } from "../utils/umami.ts";
 import { splitText } from "../utils/text.utils.ts";
+import { deleteUserAndCleanupByIdentifier } from "../utils/userDeletion.utils.ts";
 import axios, { AxiosError, isAxiosError } from "axios";
 import { Keyboard, KEYBOARD_KEYS } from "./Keyboard.ts";
 import { ExtraReplyMessage } from "telegraf/typings/telegram-types";
@@ -235,10 +236,7 @@ export async function sendTelegramMessage(
             event: "/user-deactivated",
             messageApp: "Telegram"
           });
-          await User.deleteOne({
-            messageApp: "Telegram",
-            chatId: chatId
-          });
+          await deleteUserAndCleanupByIdentifier("Telegram", chatId);
           break;
         case "Too many requests":
           await umami.log({

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -20,6 +20,7 @@ import {
   Text
 } from "whatsapp-api-js/messages";
 import { markdown2WHMarkdown, splitText } from "../utils/text.utils.ts";
+import { deleteUserAndCleanupByIdentifier } from "../utils/userDeletion.utils.ts";
 import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
 import { MAIN_MENU_MESSAGE } from "../commands/default.ts";
 import Umami from "../utils/umami.ts";
@@ -298,10 +299,7 @@ export async function sendWhatsAppMessage(
               event: "/user-deactivated",
               messageApp: "WhatsApp"
             });
-            await User.deleteOne({
-              messageApp: "WhatsApp",
-              chatId: userPhoneIdStr
-            });
+            await deleteUserAndCleanupByIdentifier("WhatsApp", userPhoneIdStr);
             break;
           default:
             console.log(resp.error);

--- a/utils/userDeletion.utils.ts
+++ b/utils/userDeletion.utils.ts
@@ -1,0 +1,74 @@
+import { Types } from "mongoose";
+import Organisation from "../models/Organisation.ts";
+import People from "../models/People.ts";
+import User from "../models/User.ts";
+import { MessageApp, IUser } from "../types.ts";
+
+function uniqueObjectIds(ids: (Types.ObjectId | undefined)[]): Types.ObjectId[] {
+  const uniqueIds = new Set<string>();
+  const result: Types.ObjectId[] = [];
+
+  ids.forEach((id) => {
+    if (id == null) return;
+    const idStr = id.toString();
+    if (!uniqueIds.has(idStr)) {
+      uniqueIds.add(idStr);
+      result.push(id);
+    }
+  });
+
+  return result;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+export async function deleteEntitiesWithNoFollowers(
+  peopleIds: Types.ObjectId[],
+  organisationIds: string[]
+): Promise<void> {
+  for (const peopleId of peopleIds) {
+    const isStillFollowed = await User.exists({
+      "followedPeople.peopleId": peopleId
+    });
+    if (isStillFollowed === null) {
+      await People.deleteOne({ _id: peopleId });
+    }
+  }
+
+  for (const wikidataId of organisationIds) {
+    const isStillFollowed = await User.exists({
+      "followedOrganisations.wikidataId": wikidataId
+    });
+    if (isStillFollowed === null) {
+      await Organisation.deleteOne({ wikidataId });
+    }
+  }
+}
+
+export async function deleteUserAndCleanup(user: IUser): Promise<void> {
+  const peopleIds = uniqueObjectIds(
+    user.followedPeople.map((followed) => followed.peopleId)
+  );
+  const organisationIds = uniqueStrings(
+    user.followedOrganisations.map((org) => org.wikidataId)
+  );
+
+  await User.deleteOne({ _id: user._id });
+  await deleteEntitiesWithNoFollowers(peopleIds, organisationIds);
+}
+
+export async function deleteUserAndCleanupByIdentifier(
+  messageApp: MessageApp,
+  chatId: string
+): Promise<void> {
+  const user = await User.findOne({ messageApp, chatId });
+
+  if (user == null) {
+    await User.deleteOne({ messageApp, chatId });
+    return;
+  }
+
+  await deleteUserAndCleanup(user);
+}


### PR DESCRIPTION
## Summary
- add shared helpers to remove orphaned followed people and organisations when users are deleted
- reuse deletion helpers in profile deletion and unfollow flows
- trigger follow cleanup when messaging errors remove users on Telegram or WhatsApp

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931bb095690832da375bb931c3f2fae)