### PR TITLE
Make telemetry logging non-blocking

### DIFF
--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -89,11 +89,13 @@ export class MatrixSession implements ISession {
   }
 
   async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    await Umami.log({
+    void Umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    });
+    }).catch((error) =>
+      logError(this.messageApp, "Error logging telemetry", error)
+    );
   }
 
   async sendMessage(

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -51,11 +51,13 @@ export class SignalSession implements ISession {
   }
 
   async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    await Umami.log({
+    void Umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    });
+    }).catch((error) =>
+      logError(this.messageApp, "Error logging telemetry", error)
+    );
   }
 
   async sendMessage(formattedData: string): Promise<void> {

--- a/entities/TelegramSession.ts
+++ b/entities/TelegramSession.ts
@@ -81,11 +81,13 @@ export class TelegramSession implements ISession {
   }
 
   async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    await Umami.log({
+    void Umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    });
+    }).catch((error) =>
+      logError(this.messageApp, "Error logging telemetry", error)
+    );
   }
 
   async sendMessage(

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -124,11 +124,13 @@ export class WhatsAppSession implements ISession {
   }
 
   async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    await Umami.log({
+    void Umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    });
+    }).catch((error) =>
+      logError(this.messageApp, "Error logging telemetry", error)
+    );
   }
 
   async sendMessage(


### PR DESCRIPTION
## Summary
- send telemetry logging asynchronously across session types so user-facing responses are not delayed
- capture telemetry failures through background error logging without blocking command handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933769d4b7c832d8c5304aa9169e72f)