### PR TITLE
Optimize Tchap messaging performance

### DIFF
--- a/docs/tchap-optimization-plan.md
+++ b/docs/tchap-optimization-plan.md
@@ -1,0 +1,17 @@
+# Plan d'optimisation pour Tchap
+
+## Constat
+- Les messages sont envoyés avec un délai fixe de 1 seconde entre chaque segment, ce qui ralentit fortement les conversations longues.
+- Chaque envoi refait plusieurs appels réseau (récupération des salons rejoints, découverte du salon direct), ce qui ajoute de la latence côté Tchap/Matrix.
+- Les erreurs liées à des salons invalides ne purgent pas toujours les caches internes, ce qui force des requêtes répétées.
+
+## Actions mises en œuvre
+1. **Réduction du throttling** : passage du délai fixe par message à 200 ms tout en conservant la logique d'exponentiel backoff sur `M_LIMIT_EXCEEDED` pour rester compatible avec le rate-limit du serveur.
+2. **Caching des salons rejoints** : ajout d'un cache court (60 s) sur la liste des salons rejoints afin d'éviter un appel `getJoinedRooms` par message tout en limitant la staleness.
+3. **Caching des salons directs** : mise en place d'un cache de 5 minutes pour la découverte du salon direct (`m.direct`), avec purge proactive lorsque le salon devient invalide ou qu'un blocage est détecté.
+4. **Amélioration des parcours d'erreur** : nettoyage des caches lorsqu'un utilisateur bloque le bot ou lorsqu'un salon enregistré n'existe plus, afin d'éviter des recherches coûteuses.
+
+## Prochaines étapes (facultatives)
+- Instrumenter les temps d'envoi/réponse côté Tchap pour confirmer le gain et surveiller d'éventuels nouveaux `M_LIMIT_EXCEEDED`.
+- Ajuster dynamiquement le délai (200 ms) en fonction des statistiques de rate-limit remontées par le serveur Tchap.
+- Enrichir les tests automatisés pour couvrir les cas de cache périmé et de recréation de salons directs.

--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -136,9 +136,15 @@ export async function sendMatrixMessage(
   const mArr = splitText(message, MATRIX_MESSAGE_CHAR_LIMIT);
   let i = 0;
   try {
-    let joinedRoomIds = await getJoinedRooms(client.matrix);
+    let joinedRoomIds: Set<string> | undefined;
 
-    if (userInfo.roomId && !joinedRoomIds.has(userInfo.roomId)) {
+    if (!userInfo.roomId) {
+      joinedRoomIds = await getJoinedRooms(client.matrix);
+    } else if (joinedRoomsCache?.expiresAt && joinedRoomsCache.expiresAt > Date.now()) {
+      joinedRoomIds = joinedRoomsCache.rooms;
+    }
+
+    if (userInfo.roomId && joinedRoomIds && !joinedRoomIds.has(userInfo.roomId)) {
       joinedRoomIds = await getJoinedRooms(client.matrix, true);
 
       try {

--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -18,7 +18,9 @@ import Umami from "../utils/umami.ts";
 import { logError } from "../utils/debugLogger.ts";
 
 export const MATRIX_MESSAGE_CHAR_LIMIT = 5000;
-const MATRIX_COOL_DOWN_DELAY_SECONDS = 1;
+const MATRIX_COOL_DOWN_DELAY_MS = 200;
+const DIRECT_ROOM_CACHE_TTL_MS = 5 * 60 * 1000;
+const JOINED_ROOMS_CACHE_TTL_MS = 60 * 1000;
 
 export const MATRIX_API_SENDING_CONCURRENCY = 1;
 
@@ -38,6 +40,11 @@ interface ExtendedMatrixClient {
   matrix: MatrixClient;
   messageApp: MessageApp;
 }
+
+const directRoomCache = new Map<string, { roomId: string; expiresAt: number }>();
+let joinedRoomsCache:
+  | { rooms: Set<string>; expiresAt: number }
+  | undefined = undefined;
 
 export class MatrixSession implements ISession {
   messageApp: MessageApp;
@@ -129,11 +136,11 @@ export async function sendMatrixMessage(
   const mArr = splitText(message, MATRIX_MESSAGE_CHAR_LIMIT);
   let i = 0;
   try {
-    const joinedRoomIds = new Set(
-      await client.matrix.getJoinedRooms().catch(() => [] as string[])
-    );
+    let joinedRoomIds = await getJoinedRooms(client.matrix);
 
     if (userInfo.roomId && !joinedRoomIds.has(userInfo.roomId)) {
+      joinedRoomIds = await getJoinedRooms(client.matrix, true);
+
       try {
         await User.updateOne(
           { messageApp: client.messageApp, chatId: userInfo.chatId },
@@ -147,6 +154,7 @@ export async function sendMatrixMessage(
         );
       }
 
+      directRoomCache.delete(userInfo.chatId);
       userInfo.roomId = undefined;
     }
 
@@ -171,6 +179,10 @@ export async function sendMatrixMessage(
           );
         }
         userInfo.roomId = dmRoomId;
+        directRoomCache.set(userInfo.chatId, {
+          roomId: dmRoomId,
+          expiresAt: Date.now() + DIRECT_ROOM_CACHE_TTL_MS
+        });
       }
     }
 
@@ -199,9 +211,9 @@ export async function sendMatrixMessage(
         messageApp: client.messageApp
       });
 
-      // prevent hitting the Signal API rate limit
+      // short pause to avoid spamming the homeserver
       await new Promise((resolve) =>
-        setTimeout(resolve, MATRIX_COOL_DOWN_DELAY_SECONDS * 1000)
+        setTimeout(resolve, MATRIX_COOL_DOWN_DELAY_MS)
       );
     }
     if (options?.separateMenuMessage)
@@ -225,7 +237,7 @@ export async function sendMatrixMessage(
           messageApp: client.messageApp
         });
         const retryAfterMs =
-          mError.retryAfterMs ?? MATRIX_COOL_DOWN_DELAY_SECONDS * 1000;
+          mError.retryAfterMs ?? MATRIX_COOL_DOWN_DELAY_MS;
         await new Promise((resolve) =>
           setTimeout(resolve, Math.pow(2, retryNumber) * retryAfterMs)
         );
@@ -242,6 +254,7 @@ export async function sendMatrixMessage(
           event: "/user-blocked-joel",
           messageApp: client.messageApp
         });
+        directRoomCache.delete(userInfo.chatId);
         await User.updateOne(
           { messageApp: client.messageApp, chatId: userInfo.chatId },
           { $set: { status: "blocked" } }
@@ -333,7 +346,12 @@ async function sendMatrixReactions(
 
   let i = 0;
   try {
-    userInfo.roomId ??= await findUserDMRoomId(client.matrix, userInfo.chatId);
+    const joinedRooms = await getJoinedRooms(client.matrix);
+    userInfo.roomId ??= await findUserDMRoomId(
+      client.matrix,
+      userInfo.chatId,
+      joinedRooms
+    );
     if (!userInfo.roomId) {
       await logError(
         userInfo.messageApp,
@@ -361,7 +379,7 @@ async function sendMatrixReactions(
           messageApp: client.messageApp
         });
         const retryAfterMs =
-          mError.retryAfterMs ?? MATRIX_COOL_DOWN_DELAY_SECONDS * 1000;
+          mError.retryAfterMs ?? MATRIX_COOL_DOWN_DELAY_MS;
         await new Promise((resolve) =>
           setTimeout(resolve, Math.pow(2, retryNumber) * retryAfterMs)
         );
@@ -387,23 +405,57 @@ async function sendMatrixReactions(
 
 type DirectRoomData = Record<string, string[]>;
 
+async function getJoinedRooms(
+  client: MatrixClient,
+  forceRefresh = false
+): Promise<Set<string>> {
+  const now = Date.now();
+  if (!forceRefresh && joinedRoomsCache?.expiresAt && joinedRoomsCache.expiresAt > now)
+    return joinedRoomsCache.rooms;
+
+  const roomIds = await client.getJoinedRooms().catch(() => [] as string[]);
+
+  joinedRoomsCache = {
+    rooms: new Set(roomIds),
+    expiresAt: now + JOINED_ROOMS_CACHE_TTL_MS
+  };
+
+  return joinedRoomsCache.rooms;
+}
+
 async function findUserDMRoomId(
   client: MatrixClient,
   userId: string,
   joinedRoomIds?: Set<string>
 ): Promise<string | undefined> {
+  const cached = directRoomCache.get(userId);
+  const now = Date.now();
+  if (cached?.expiresAt && cached.expiresAt > now) return cached.roomId;
+
   const data = (await client
     .getAccountData("m.direct")
     .catch(() => ({}) as DirectRoomData)) as DirectRoomData;
   const rooms = Array.isArray(data[userId]) ? data[userId] : [];
-  if (!rooms.length) return undefined;
+  if (!rooms.length) {
+    directRoomCache.delete(userId);
+    return undefined;
+  }
 
   let joinedRooms = joinedRoomIds;
-  joinedRooms ??= new Set(
-    await client.getJoinedRooms().catch(() => [] as string[])
-  );
+  joinedRooms ??= await getJoinedRooms(client);
 
-  return rooms.find((roomId) => joinedRooms.has(roomId));
+  const roomId = rooms.find((id) => joinedRooms.has(id));
+  if (roomId == null) {
+    directRoomCache.delete(userId);
+    return undefined;
+  }
+
+  directRoomCache.set(userId, {
+    roomId,
+    expiresAt: now + DIRECT_ROOM_CACHE_TTL_MS
+  });
+
+  return roomId;
 }
 export async function extractMatrixSession(
   session: ISession,


### PR DESCRIPTION
## Summary
- document a focused optimization plan to speed up Tchap messaging
- cache joined-room and DM lookups while cleaning caches on invalid rooms or blocks
- reduce Matrix/Tchap send delay and keep exponential backoff for rate limits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69337839ef40832d9de1e81d16620a23)