### PR TITLE
Make umami logging fire-and-forget

### DIFF
--- a/apps/matrixApp.ts
+++ b/apps/matrixApp.ts
@@ -184,7 +184,7 @@ function handleCommand(roomId: string, event: MatrixRoomEvent) {
               { $set: { status: "active" }, $unset: { roomId: 1 } },
               { runValidators: true }
             );
-            await umami.log({
+            umami.log({
               event: "/user-blocked-joel",
               messageApp: matrixApp
             });
@@ -216,7 +216,7 @@ function handleCommand(roomId: string, event: MatrixRoomEvent) {
                   { _id: previousUser._id },
                   { $set: { status: "active", roomId: roomId } }
                 );
-                await umami.log({
+                umami.log({
                   event: "/user-unblocked-joel",
                   messageApp: matrixApp
                 });

--- a/apps/whatsAppApp.ts
+++ b/apps/whatsAppApp.ts
@@ -133,7 +133,7 @@ app.post("/webhook", async (req, res) => {
     if (now - ts > MAX_AGE_SEC) {
       // Acknowledge but skip processing so Meta doesn't retry
       res.sendStatus(200);
-      await umami.log({
+      umami.log({
         event: "/message-received-echo-refused",
         messageApp: "WhatsApp"
       });
@@ -291,7 +291,7 @@ whatsAppAPI.on.message = async ({ phoneID, from, message }) => {
   if (msgText == null) return;
 
   if (rememberInboundMessage(message.id)) {
-    await umami.log({
+    umami.log({
       event: "/message-received-echo-refused",
       messageApp: "WhatsApp"
     });

--- a/commands/default.ts
+++ b/commands/default.ts
@@ -10,7 +10,7 @@ import { logError } from "../utils/debugLogger.ts";
 export const defaultCommand = async (session: ISession): Promise<void> => {
   try {
     if (session.isReply) return;
-    await session.log({ event: "/default-message" });
+    session.log({ event: "/default-message" });
     await session.sendMessage("Je n'ai pas compris votre message 🥺", {
       separateMenuMessage: true
     });
@@ -22,7 +22,7 @@ export const defaultCommand = async (session: ISession): Promise<void> => {
 export const MAIN_MENU_MESSAGE = "Utilisez le clavier ci-dessous.";
 
 export const mainMenuCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/main-menu-message" });
+  session.log({ event: "/main-menu-message" });
   await sendMainMenu(
     {
       messageApp: session.messageApp,

--- a/commands/deleteProfile.ts
+++ b/commands/deleteProfile.ts
@@ -48,7 +48,7 @@ async function handleDeleteProfileAnswer(
     await session.sendMessage(
       `🗑 Votre profil a bien été supprimé ! 👋\\splitUn profil vierge sera créé lors de l'ajout du prochain suivi ⚠️`
     );
-    await session.log({ event: "/user-deletion-self" });
+    session.log({ event: "/user-deletion-self" });
   } else {
     await session.sendMessage("Suppression annulée.");
   }
@@ -59,7 +59,7 @@ async function handleDeleteProfileAnswer(
 export const deleteProfileCommand = async (
   session: ISession
 ): Promise<void> => {
-  await session.log({ event: "/delete-profile" });
+  session.log({ event: "/delete-profile" });
   try {
     if (session.user == null) {
       await session.sendMessage(

--- a/commands/ena.ts
+++ b/commands/ena.ts
@@ -275,7 +275,7 @@ async function handlePromoConfirmation(
 
 export const enaCommand = async (session: ISession): Promise<void> => {
   try {
-    await session.log({ event: "/ena" });
+    session.log({ event: "/ena" });
     await askPromoQuestion(session);
   } catch (error) {
     await logError(session.messageApp, "Error in /enaCommand command", error);
@@ -284,7 +284,7 @@ export const enaCommand = async (session: ISession): Promise<void> => {
 
 export const promosCommand = async (session: ISession): Promise<void> => {
   try {
-    await session.log({ event: "/ena-list" });
+    session.log({ event: "/ena-list" });
     let text = `Les périodes et noms des promotions successives sont:\n\n`;
 
     // Promotions INSP

--- a/commands/followFunction.ts
+++ b/commands/followFunction.ts
@@ -115,7 +115,7 @@ function parseFunctionSelection(selectionText: string): FunctionTags[] {
 export const followFunctionCommand = async (
   session: ISession
 ): Promise<void> => {
-  await session.log({ event: "/follow-function" });
+  session.log({ event: "/follow-function" });
   try {
     await session.sendTypingAction();
 

--- a/commands/followOrganisation.ts
+++ b/commands/followOrganisation.ts
@@ -98,7 +98,7 @@ async function processOrganisationSearch(
   orgName: string,
   triggerUmami = true
 ): Promise<void> {
-  if (triggerUmami) await session.log({ event: "/follow-organisation" });
+  if (triggerUmami) session.log({ event: "/follow-organisation" });
 
   const orgResults = await searchOrganisationWikidataId(
     orgName,
@@ -260,7 +260,7 @@ async function handleOrganisationSelection(
 
 export const searchOrganisation = async (session: ISession) => {
   try {
-    await session.log({ event: "/follow-organisation" });
+    session.log({ event: "/follow-organisation" });
     await askOrganisationSearch(session);
   } catch (error) {
     await logError(
@@ -301,7 +301,7 @@ export const followOrganisationsFromWikidataIdStr = async (
       await searchOrganisationFromStr(session, msg, false);
       return;
     }
-    if (triggerUmami) await session.log({ event: "/follow-organisation" });
+    if (triggerUmami) session.log({ event: "/follow-organisation" });
     await session.sendTypingAction();
 
     const selectedWikiDataIds = msg

--- a/commands/help.ts
+++ b/commands/help.ts
@@ -7,7 +7,7 @@ import { logError } from "../utils/debugLogger.ts";
 import { getBuildInfo } from "../utils/buildInfo.ts";
 
 export const helpCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/help" });
+  session.log({ event: "/help" });
   await session.sendTypingAction();
 
   const helpText = getHelpText(session);
@@ -60,7 +60,7 @@ export const getHelpText = (session: ISession): string => {
 };
 
 export const buildInfoCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/build" });
+  session.log({ event: "/build" });
   await session.sendTypingAction();
 
   const { uptime, commitHash, commitUrl } = await getBuildInfo();
@@ -82,7 +82,7 @@ export const buildInfoCommand = async (session: ISession): Promise<void> => {
 };
 
 export const statsCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/stats" });
+  session.log({ event: "/stats" });
   await session.sendTypingAction();
   await session.sendMessage(await statsText(session), {
     separateMenuMessage: true

--- a/commands/importExport.ts
+++ b/commands/importExport.ts
@@ -18,7 +18,7 @@ const IMPORTER_CODE_PROMPT =
   "Saisir le code d'import que vous avez reçu (valable 4 heures).";
 
 export const exportCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/data-export" });
+  session.log({ event: "/data-export" });
   await session.sendTypingAction();
 
   if (session.user == null || session.user.followsNothing()) {
@@ -59,7 +59,7 @@ export const exportCommand = async (session: ISession): Promise<void> => {
 };
 
 export const importCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/data-import" });
+  session.log({ event: "/data-import" });
   await session.sendTypingAction();
 
   await askFollowUpQuestion(session, IMPORTER_CODE_PROMPT, handleImporterCode, {
@@ -169,7 +169,7 @@ async function handleImporterCode(
   sourceUser.transferData = undefined;
   await sourceUser.save();
 
-  await session.log({ event: "/data-import-confirmed" });
+  session.log({ event: "/data-import-confirmed" });
   await session.sendMessage(
     `Les éléments suivants ont été copiés depuis le compte source :\n\n${summary}`
   );

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -191,7 +191,7 @@ export async function getAllUserFollowsOrdered(
 }
 
 export const listCommand = async (session: ISession) => {
-  await session.log({ event: "/list" });
+  session.log({ event: "/list" });
 
   try {
     await session.sendTypingAction();
@@ -268,7 +268,7 @@ async function handleUnfollowAnswer(
 }
 
 export const unfollowCommand = async (session: ISession) => {
-  await session.log({ event: "/unfollow" });
+  session.log({ event: "/unfollow" });
   try {
     await session.sendTypingAction();
 
@@ -296,7 +296,7 @@ export const unfollowFromStr = async (
   triggerUmami = true
 ): Promise<boolean> => {
   try {
-    if (triggerUmami) await session.log({ event: "/unfollow" });
+    if (triggerUmami) session.log({ event: "/unfollow" });
 
     if (session.user == null) {
       await session.sendMessage(noDataText);
@@ -527,7 +527,7 @@ export const unfollowFromStr = async (
     // Delete the user if it doesn't follow anything any more
     if (session.user.followsNothing()) {
       await User.deleteOne({ _id: session.user._id });
-      await session.log({ event: "/user-deletion-no-follow" });
+      session.log({ event: "/user-deletion-no-follow" });
     }
 
     await session.sendMessage(text);

--- a/commands/search.ts
+++ b/commands/search.ts
@@ -97,7 +97,7 @@ async function handleSearchAnswer(
 }
 
 export const searchCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/search" });
+  session.log({ event: "/search" });
   await askSearchQuestion(session);
 };
 
@@ -105,7 +105,7 @@ export const fullHistoryCommand = async (
   session: ISession,
   msg?: string
 ): Promise<void> => {
-  await session.log({ event: "/history" });
+  session.log({ event: "/history" });
 
   if (msg == undefined) {
     await logError("Telegram", "/history command called without msg argument");
@@ -335,7 +335,7 @@ export const followCommand = async (
   msg: string
 ): Promise<void> => {
   try {
-    await session.log({ event: "/follow" });
+    session.log({ event: "/follow" });
 
     const msgSplit = msg.split(" ");
 
@@ -392,7 +392,7 @@ export const manualFollowCommand = async (
   session: ISession,
   msg?: string
 ): Promise<void> => {
-  await session.log({ event: "/follow-name" });
+  session.log({ event: "/follow-name" });
 
   const personNameSplit = cleanPeopleName(
     removeSpecialCharacters(msg ?? "")

--- a/commands/start.ts
+++ b/commands/start.ts
@@ -21,14 +21,14 @@ export const startCommand = async (
     if (commandMsg != null) {
       const commandMsg = messageSplit[1].trim();
       if (commandMsg.toLowerCase().startsWith("suivreo"))
-        await session.log({ event: "/start-from-organisation" });
+        session.log({ event: "/start-from-organisation" });
       else if (commandMsg.toLowerCase().startsWith("suivref"))
-        await session.log({ event: "/start-from-tag" });
+        session.log({ event: "/start-from-tag" });
       else if (
         commandMsg.toLowerCase().startsWith("suiv") ||
         commandMsg.toLowerCase().startsWith("recherche")
       )
-        await session.log({ event: "/start-from-people" });
+        session.log({ event: "/start-from-people" });
 
       await session.sendMessage(getHelpText(session), {
         forceNoKeyboard: true
@@ -40,7 +40,7 @@ export const startCommand = async (
       await session.sendMessage(getHelpText(session), {
         separateMenuMessage: true
       });
-      await session.log({ event: "/start" });
+      session.log({ event: "/start" });
     }
   } catch (error) {
     await logError(session.messageApp, "Error in /start command", error);

--- a/commands/textAlert.ts
+++ b/commands/textAlert.ts
@@ -211,7 +211,7 @@ async function handleTextAlertConfirmation(
     let responseText = `Vous suivez déjà une alerte pour « ${context.alertString} ». ✅`;
     if (wasAdded) {
       responseText = `Alerte enregistrée pour « ${context.alertString} » ✅`;
-      await session.log({ event: "/follow-meta" });
+      session.log({ event: "/follow-meta" });
     }
 
     await session.sendMessage(responseText, {
@@ -249,7 +249,7 @@ async function handleTextAlertConfirmation(
 }
 
 export const textAlertCommand = async (session: ISession): Promise<void> => {
-  await session.log({ event: "/text-alert" });
+  session.log({ event: "/text-alert" });
   try {
     await session.sendTypingAction();
     await askTextAlertQuestion(session);

--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -14,7 +14,6 @@ import {
 } from "../utils/text.utils.ts";
 import { MatrixClient, MatrixError } from "matrix-bot-sdk";
 import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
-import Umami from "../utils/umami.ts";
 import { logError } from "../utils/debugLogger.ts";
 
 export const MATRIX_MESSAGE_CHAR_LIMIT = 1000;
@@ -97,14 +96,12 @@ export class MatrixSession implements ISession {
     //await this.telegramBot.sendChatAction(this.chatIdTg, "typing");
   }
 
-  async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    void Umami.log({
+  log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
+    umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    }).catch((error) =>
-      logError(this.messageApp, "Error logging telemetry", error)
-    );
+    });
   }
 
   async sendMessage(
@@ -128,7 +125,7 @@ export async function sendMatrixMessage(
   retryNumber = 0
 ): Promise<boolean> {
   if (retryNumber > 5) {
-    await umami.log({
+    umami.log({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: client.messageApp
     });
@@ -223,7 +220,7 @@ export async function sendMatrixMessage(
         formatted_body: markdown2html(mArr[i])
       });
 
-      await umami.log({
+      umami.log({
         event: "/message-sent",
         messageApp: client.messageApp
       });
@@ -249,7 +246,7 @@ export async function sendMatrixMessage(
     const mError = error as MatrixError;
     switch (mError.errcode) {
       case "M_LIMIT_EXCEEDED": {
-        await umami.log({
+        umami.log({
           event: "/message-fail-too-many-requests",
           messageApp: client.messageApp
         });
@@ -266,7 +263,7 @@ export async function sendMatrixMessage(
         );
       }
       case "M_FORBIDDEN": // user blocked the bot, user left the room ...
-        await umami.log({
+        umami.log({
           event: "/user-blocked-joel",
           messageApp: client.messageApp
         });
@@ -322,7 +319,7 @@ export async function sendPollMenu(
     "org.matrix.msc3381.poll.start",
     content
   );
-  await umami.log({ event: "/message-sent", messageApp: client.messageApp });
+  umami.log({ event: "/message-sent", messageApp: client.messageApp });
 
   return true;
 }
@@ -353,7 +350,7 @@ async function sendMatrixReactions(
   retryNumber = 0
 ): Promise<boolean> {
   if (retryNumber > 5) {
-    await umami.log({
+    umami.log({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: client.messageApp
     });
@@ -390,7 +387,7 @@ async function sendMatrixReactions(
     const mError = error as MatrixError;
     switch (mError.errcode) {
       case "M_LIMIT_EXCEEDED": {
-        await umami.log({
+        umami.log({
           event: "/message-fail-too-many-requests",
           messageApp: client.messageApp
         });
@@ -408,7 +405,7 @@ async function sendMatrixReactions(
       }
       default:
         console.log(error);
-        await umami.log({
+        umami.log({
           event: "/console-log",
           messageApp: userInfo.messageApp
         });

--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -65,7 +65,7 @@ export async function loadUser(session: ISession): Promise<IUser | null> {
     } else {
       if (user.followsNothing()) {
         await User.deleteOne({ _id: user._id });
-        await umami.log({ event: "/user-deletion-no-follow" });
+        umami.log({ event: "/user-deletion-no-follow" });
         return null;
       }
       if (

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -4,7 +4,6 @@ import { loadUser, recordSuccessfulDelivery } from "./Session.ts";
 import umami, { UmamiEvent } from "../utils/umami.ts";
 import { markdown2plainText, splitText } from "../utils/text.utils.ts";
 import { SignalCli } from "signal-sdk";
-import Umami from "../utils/umami.ts";
 import { logError } from "../utils/debugLogger.ts";
 
 const SignalMessageApp: MessageApp = "Signal";
@@ -50,14 +49,12 @@ export class SignalSession implements ISession {
     // TODO: check implementation in Signal
   }
 
-  async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    void Umami.log({
+  log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
+    umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    }).catch((error) =>
-      logError(this.messageApp, "Error logging telemetry", error)
-    );
+    });
   }
 
   async sendMessage(formattedData: string): Promise<void> {
@@ -103,7 +100,7 @@ export async function sendSignalAppMessage(
     for (const elem of mArr) {
       await signalCli.sendMessage(userPhoneIdInt, elem);
 
-      await umami.log({ event: "/message-sent", messageApp: "Signal" });
+      umami.log({ event: "/message-sent", messageApp: "Signal" });
 
       // prevent hitting the Signal API rate limit
       await new Promise((resolve) =>

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -23,7 +23,6 @@ import { markdown2WHMarkdown, splitText } from "../utils/text.utils.ts";
 import { deleteUserAndCleanupByIdentifier } from "../utils/userDeletion.utils.ts";
 import { Keyboard, KEYBOARD_KEYS, KeyboardKey } from "./Keyboard.ts";
 import { MAIN_MENU_MESSAGE } from "../commands/default.ts";
-import Umami from "../utils/umami.ts";
 import { logError } from "../utils/debugLogger.ts";
 
 export const WHATSAPP_MESSAGE_CHAR_LIMIT = 900;
@@ -123,14 +122,12 @@ export class WhatsAppSession implements ISession {
     // TODO: check implementation in WH
   }
 
-  async log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
-    void Umami.log({
+  log(args: { event: UmamiEvent; payload?: Record<string, unknown> }) {
+    umami.log({
       event: args.event,
       messageApp: this.messageApp,
       payload: args.payload
-    }).catch((error) =>
-      logError(this.messageApp, "Error logging telemetry", error)
-    );
+    });
   }
 
   async sendMessage(
@@ -183,7 +180,7 @@ export async function sendWhatsAppMessage(
   retryNumber = 0
 ): Promise<boolean> {
   if (retryNumber > 5) {
-    await umami.log({
+    umami.log({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: "WhatsApp"
     });
@@ -274,7 +271,7 @@ export async function sendWhatsAppMessage(
           case 130429:
           case 131048:
           case 131056:
-            await umami.log({
+            umami.log({
               event: "/message-fail-too-many-requests",
               messageApp: "WhatsApp"
             });
@@ -290,7 +287,7 @@ export async function sendWhatsAppMessage(
             );
 
           case 131008: // user blocked the bot
-            await umami.log({
+            umami.log({
               event: "/user-blocked-joel",
               messageApp: "WhatsApp"
             });
@@ -301,7 +298,7 @@ export async function sendWhatsAppMessage(
             break;
           case 131026: // user not on WhatsApp
           case 131030:
-            await umami.log({
+            umami.log({
               event: "/user-deactivated",
               messageApp: "WhatsApp"
             });
@@ -312,7 +309,7 @@ export async function sendWhatsAppMessage(
         }
         return false;
       }
-      await umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
+      umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
 
       if (burstMode || (i == mArr.length - 1 && options?.separateMenuMessage)) {
         // prevent hitting the WH API rate limit
@@ -346,7 +343,7 @@ export async function sendWhatsAppMessage(
         return false;
       }
       numberMessageBurst += 1;
-      await umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
+      umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
     }
 
     // make up for the cooldown delay borrowed in the burst mode

--- a/models/Organisation.ts
+++ b/models/Organisation.ts
@@ -34,7 +34,7 @@ OrganisationSchema.static(
     let organisation: IOrganisation | null = await query.exec();
 
     if (organisation === null) {
-      await umami.log({ event: "/new-organisation" });
+      umami.log({ event: "/new-organisation" });
       organisation = await this.create({
         nom: args.nom,
         wikidataId: args.wikidataId.toUpperCase()

--- a/models/People.ts
+++ b/models/People.ts
@@ -36,7 +36,7 @@ PeopleSchema.static(
     let people: IPeople | null = await query.exec();
 
     if (people == null) {
-      await umami.log({ event: "/person-added" });
+      umami.log({ event: "/person-added" });
       people = await this.create({
         nom: peopleInfo.nom,
         prenom: peopleInfo.prenom

--- a/models/User.ts
+++ b/models/User.ts
@@ -166,7 +166,7 @@ UserSchema.static(
         return user;
       }
 
-      await umami.log({ event: "/new-user", messageApp: session.messageApp });
+      umami.log({ event: "/new-user", messageApp: session.messageApp });
       const newUser = await this.create({
         chatId: session.chatId,
         messageApp: session.messageApp,
@@ -190,7 +190,7 @@ UserSchema.method(
     let needSaving = false;
 
     if (this.status === "blocked") {
-      await umami.log({
+      umami.log({
         event: "/user-unblocked-joel",
         messageApp: this.messageApp
       });
@@ -208,7 +208,7 @@ UserSchema.method(
       this.lastInteractionDay.toDateString() !== currentDay.toDateString()
     ) {
       this.lastInteractionDay = currentDay;
-      await umami.log({
+      umami.log({
         event: "/daily-active-user",
         messageApp: this.messageApp
       });
@@ -225,7 +225,7 @@ UserSchema.method(
       thisWeek !== lastInteractionWeek
     ) {
       this.lastInteractionWeek = currentDay;
-      await umami.log({
+      umami.log({
         event: "/weekly-active-user",
         messageApp: this.messageApp
       });
@@ -241,7 +241,7 @@ UserSchema.method(
       const startMonth = new Date(currentDay);
       startMonth.setDate(1);
       this.lastInteractionMonth = startMonth;
-      await umami.log({
+      umami.log({
         event: "/monthly-active-user",
         messageApp: this.messageApp
       });

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -173,7 +173,7 @@ async function sendAlertStringUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  await umami.log({
+  umami.log({
     event: "/notification-update-meta",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -273,7 +273,7 @@ async function sendTagUpdates(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  await umami.log({
+  umami.log({
     event: "/notification-update-function",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -227,7 +227,7 @@ async function sendNameMentionUpdates(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  await umami.log({
+  umami.log({
     event: "/notification-update-name",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -282,7 +282,7 @@ async function sendOrganisationUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  await umami.log({
+  umami.log({
     event: "/notification-update-organisation",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -267,7 +267,7 @@ async function sendPeopleUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  await umami.log({
+  umami.log({
     event: "/notification-update-people",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -125,7 +125,7 @@ async function saveNewMetaPublications(
 
   if (newRecords.length > 0) {
     await Publication.insertMany(newRecords, { ordered: false });
-    await umami.log({
+    umami.log({
       event: "/publication-added",
       payload: { nb: newRecords.length }
     });
@@ -231,7 +231,7 @@ export async function runNotificationProcess(
   }
 
   for (const appType of targetApps) {
-    await umami.log({
+    umami.log({
       event: "/notification-process-completed",
       messageApp: appType
     });

--- a/scripts/broadcastMessage.ts
+++ b/scripts/broadcastMessage.ts
@@ -90,7 +90,7 @@ https://www.joel-officiel.fr/\\split
     console.log(
       `Broadcast completed: ${String(result.succeeded)}/${String(result.attempted)} deliveries succeeded.`
     );
-    await umami.log({ event: "/message-sent-broadcast" });
+    umami.log({ event: "/message-sent-broadcast" });
     process.exit(result.failed === 0 ? 0 : 2);
   } catch (error) {
     console.error("Broadcast failed:", error);

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,7 +30,7 @@ export interface ISession {
     options?: MessageSendingOptionsInternal
   ) => Promise<void>;
   sendTypingAction: () => Promise<void>;
-  log: (args: { event: UmamiEvent }) => Promise<void>;
+  log: (args: { event: UmamiEvent }) => void;
 }
 
 // fields are undefined for users created before implementation

--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -49,7 +49,7 @@ async function logJORFSearchError(
     | "meta",
   messageApp?: MessageApp
 ) {
-  await umami.log({
+  umami.log({
     event: "/jorfsearch-error",
     messageApp,
     payload: { [errorType]: true }
@@ -62,7 +62,7 @@ export async function callJORFSearchPeople(
   retryNumber = 0
 ): Promise<JORFSearchItem[] | null> {
   try {
-    await umami.log({
+    umami.log({
       event: "/jorfsearch-request-people",
       messageApp
     });
@@ -92,7 +92,7 @@ export async function callJORFSearchPeople(
             ? `${responseUrl}${/([?&])format=JSON\b/.test(responseUrl) ? "" : "&format=JSON"}`
             : `${responseUrl}?format=JSON`;
 
-          await umami.log({
+          umami.log({
             event: "/jorfsearch-request-people-formatted",
             messageApp
           });
@@ -137,7 +137,7 @@ export async function callJORFSearchDay(
   retryNumber = 0
 ): Promise<JORFSearchItem[] | null> {
   try {
-    await umami.log({ event: "/jorfsearch-request-date" });
+    umami.log({ event: "/jorfsearch-request-date" });
     const dateDMY = dateToString(day, "DMY");
     const dateYMD = dateToString(day, "YMD");
 
@@ -192,7 +192,7 @@ export async function callJORFSearchMetaDay(
   retryNumber = 0
 ): Promise<JORFSearchPublication[] | null> {
   try {
-    await umami.log({ event: "/jorfsearch-request-meta" });
+    umami.log({ event: "/jorfsearch-request-meta" });
 
     const dateYMD = dateToString(day, "YMD");
 
@@ -250,7 +250,7 @@ export async function callJORFSearchTag(
   retryNumber = 0
 ): Promise<JORFSearchItem[] | null> {
   try {
-    await umami.log({ event: "/jorfsearch-request-tag", messageApp });
+    umami.log({ event: "/jorfsearch-request-tag", messageApp });
     return await axios
       .get<JORFSearchResponse>(
         getJORFSearchLinkFunctionTag(tag, true, tagValue),
@@ -300,7 +300,7 @@ export async function callJORFSearchOrganisation(
   retryNumber = 0
 ): Promise<JORFSearchItem[] | null> {
   try {
-    await umami.log({ event: "/jorfsearch-request-organisation", messageApp });
+    umami.log({ event: "/jorfsearch-request-organisation", messageApp });
     return await axios
       .get<JORFSearchResponse>(
         encodeURI(
@@ -359,7 +359,7 @@ export async function searchOrganisationWikidataId(
   if (org_name.length == 0) throw new Error("Empty org_name");
 
   try {
-    await umami.log({
+    umami.log({
       event: "/jorfsearch-request-wikidata-names",
       messageApp
     });
@@ -412,7 +412,7 @@ export async function searchOrganisationWikidataId(
         }));
       });
   } catch (error) {
-    await umami.log({
+    umami.log({
       event: "/jorfsearch-error",
       messageApp,
       payload: { wikidata_name: true }
@@ -431,7 +431,7 @@ export async function callJORFSearchReference(
   messageApp: MessageApp
 ): Promise<JORFSearchItem[] | null> {
   try {
-    await umami.log({ event: "/jorfsearch-request-reference", messageApp });
+    umami.log({ event: "/jorfsearch-request-reference", messageApp });
     return await axios
       .get<JORFSearchResponse>(
         encodeURI(
@@ -452,7 +452,7 @@ export async function callJORFSearchReference(
         return cleanJORFItems(res.data);
       });
   } catch (error) {
-    await umami.log({
+    umami.log({
       event: "/jorfsearch-error",
       messageApp,
       payload: { reference: true }

--- a/utils/debugLogger.ts
+++ b/utils/debugLogger.ts
@@ -95,7 +95,7 @@ export const logError = async (
   error?: unknown
 ): Promise<void> => {
   logToConsole("error", message, error);
-  await umami.log({ event: "/console-log", messageApp });
+  umami.log({ event: "/console-log", messageApp });
   await sendTelegramDebugMessage(
     buildLogMessage("error", messageApp, message, error)
   );

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -7,7 +7,7 @@ export interface UmamiNotificationData {
   total_records_nb: number;
 }
 
-export const log = async (args: {
+export const log = (args: {
   event: UmamiEvent;
   messageApp?: MessageApp;
   notificationData?: UmamiNotificationData;
@@ -48,11 +48,9 @@ export const log = async (args: {
     }
   };
 
-  try {
-    await axios.post(endpoint, payload, options);
-  } catch (error) {
+  void axios.post(endpoint, payload, options).catch((error) => {
     console.log(error);
-  }
+  });
 };
 
 export default {

--- a/utils/userDeletion.utils.ts
+++ b/utils/userDeletion.utils.ts
@@ -37,7 +37,7 @@ export async function deleteEntitiesWithNoFollowers(
     });
     if (isStillFollowed === null) {
       await People.deleteOne({ _id: peopleId });
-      await umami.log({ event: "/person-deletion-no-follow" });
+      umami.log({ event: "/person-deletion-no-follow" });
     }
   }
 
@@ -47,7 +47,7 @@ export async function deleteEntitiesWithNoFollowers(
     });
     if (isStillFollowed === null) {
       await Organisation.deleteOne({ wikidataId });
-      await umami.log({ event: "/organisation-deletion-no-follow" });
+      umami.log({ event: "/organisation-deletion-no-follow" });
     }
   }
 }


### PR DESCRIPTION
## Summary
- make umami.log fire-and-forget and update its signature
- align session logging interfaces/implementations and update call sites to the new synchronous logging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69338ebe16f4832d8e78248a27f58ed6)