### PR TITLE
Add async umami logging for notification workflows

### DIFF
--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -6,7 +6,7 @@ import {
   MiniUserInfo,
   recordSuccessfulDelivery
 } from "./Session.ts";
-import umami, { UmamiEvent } from "../utils/umami.ts";
+import umami, { UmamiEvent, UmamiLogger } from "../utils/umami.ts";
 import {
   markdown2html,
   markdown2plainText,
@@ -126,6 +126,8 @@ export async function sendMatrixMessage(
   options?: MessageSendingOptionsInternal,
   retryNumber = 0
 ): Promise<boolean> {
+  const umamiLogger: UmamiLogger =
+    options?.useAsyncUmamiLog === true ? umami.logAsync : umami.log;
   let keyboard = options?.keyboard;
   if (!options?.forceNoKeyboard) keyboard ??= mainMenuKeyboardMatrix;
 
@@ -215,7 +217,7 @@ export async function sendMatrixMessage(
         formatted_body: markdown2html(mArr[i])
       });
 
-      umami.log({
+      umamiLogger({
         event: "/message-sent",
         messageApp: client.messageApp
       });
@@ -251,10 +253,10 @@ export async function sendMatrixMessage(
     switch (errCode) {
       case "M_LIMIT_EXCEEDED": {
         if (retryNumber > MAX_MESSAGE_RETRY) {
-          umami.log({ event: "/message-fail-too-many-requests-aborted" });
+          umamiLogger({ event: "/message-fail-too-many-requests-aborted" });
           return false;
         }
-        umami.log({
+        umamiLogger({
           event: "/message-fail-too-many-requests",
           messageApp: client.messageApp
         });

--- a/entities/MatrixSession.ts
+++ b/entities/MatrixSession.ts
@@ -217,7 +217,7 @@ export async function sendMatrixMessage(
         formatted_body: markdown2html(mArr[i])
       });
 
-      umamiLogger({
+      await umamiLogger({
         event: "/message-sent",
         messageApp: client.messageApp
       });
@@ -253,10 +253,10 @@ export async function sendMatrixMessage(
     switch (errCode) {
       case "M_LIMIT_EXCEEDED": {
         if (retryNumber > MAX_MESSAGE_RETRY) {
-          umamiLogger({ event: "/message-fail-too-many-requests-aborted" });
+          await umamiLogger({ event: "/message-fail-too-many-requests-aborted" });
           return false;
         }
-        umamiLogger({
+        await umamiLogger({
           event: "/message-fail-too-many-requests",
           messageApp: client.messageApp
         });

--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -124,6 +124,7 @@ export interface MessageSendingOptionsInternal {
   keyboard?: Keyboard;
   forceNoKeyboard?: boolean;
   separateMenuMessage?: boolean;
+  useAsyncUmamiLog?: boolean;
 }
 
 export interface MessageSendingOptionsExternal {
@@ -135,6 +136,7 @@ export interface MessageSendingOptionsExternal {
   forceNoKeyboard?: boolean;
   keyboard?: Keyboard;
   separateMenuMessage?: boolean;
+  useAsyncUmamiLog?: boolean;
 }
 
 export interface MiniUserInfo {
@@ -174,7 +176,8 @@ export async function sendMessage(
       return await sendSignalAppMessage(
         options.signalCli,
         userInfo.chatId,
-        message
+        message,
+        options
       );
 
     case "Telegram":
@@ -184,7 +187,9 @@ export async function sendMessage(
         options.telegramBotToken,
         userInfo.chatId,
         message,
-        options.keyboard
+        options.keyboard,
+        0,
+        options
       );
 
     case "WhatsApp":

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -110,7 +110,7 @@ export async function sendSignalAppMessage(
     for (const elem of mArr) {
       await signalCli.sendMessage(userPhoneIdInt, elem);
 
-      umamiLogger({ event: "/message-sent", messageApp: "Signal" });
+      await umamiLogger({ event: "/message-sent", messageApp: "Signal" });
 
       // prevent hitting the Signal API rate limit
       await new Promise((resolve) =>

--- a/entities/SignalSession.ts
+++ b/entities/SignalSession.ts
@@ -1,7 +1,11 @@
 import { ISession, IUser, MessageApp } from "../types.ts";
 import User from "../models/User.ts";
-import { loadUser, recordSuccessfulDelivery } from "./Session.ts";
-import umami, { UmamiEvent } from "../utils/umami.ts";
+import {
+  loadUser,
+  MessageSendingOptionsInternal,
+  recordSuccessfulDelivery
+} from "./Session.ts";
+import umami, { UmamiEvent, UmamiLogger } from "../utils/umami.ts";
 import { markdown2plainText, splitText } from "../utils/text.utils.ts";
 import { SignalCli } from "signal-sdk";
 import { logError } from "../utils/debugLogger.ts";
@@ -92,8 +96,11 @@ export async function extractSignalAppSession(
 export async function sendSignalAppMessage(
   signalCli: SignalCli,
   userPhoneId: string,
-  message: string
+  message: string,
+  options?: MessageSendingOptionsInternal
 ): Promise<boolean> {
+  const umamiLogger: UmamiLogger =
+    options?.useAsyncUmamiLog === true ? umami.logAsync : umami.log;
   try {
     const cleanMessage = markdown2plainText(message);
     const userPhoneIdInt = userPhoneId.startsWith("+")
@@ -103,7 +110,7 @@ export async function sendSignalAppMessage(
     for (const elem of mArr) {
       await signalCli.sendMessage(userPhoneIdInt, elem);
 
-      umami.log({ event: "/message-sent", messageApp: "Signal" });
+      umamiLogger({ event: "/message-sent", messageApp: "Signal" });
 
       // prevent hitting the Signal API rate limit
       await new Promise((resolve) =>

--- a/entities/TelegramSession.ts
+++ b/entities/TelegramSession.ts
@@ -155,7 +155,7 @@ export async function sendTelegramMessage(
   const umamiLogger: UmamiLogger =
     options?.useAsyncUmamiLog === true ? umami.logAsync : umami.log;
   if (retryNumber > 5) {
-    umamiLogger({
+    await umamiLogger({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: "Telegram"
     });
@@ -186,7 +186,7 @@ export async function sendTelegramMessage(
         `https://api.telegram.org/bot${botToken}/sendMessage`,
         payload
       );
-      umamiLogger({ event: "/message-sent", messageApp: "Telegram" });
+      await umamiLogger({ event: "/message-sent", messageApp: "Telegram" });
 
       // prevent hitting the Telegram API rate limit
       await new Promise((resolve) =>
@@ -198,7 +198,7 @@ export async function sendTelegramMessage(
       const error = err as AxiosError<TelegramAPIError>;
       switch (error.response?.data.description) {
         case "Forbidden: bot was blocked by the user":
-          umamiLogger({
+          await umamiLogger({
             event: "/user-blocked-joel",
             messageApp: "Telegram"
           });
@@ -208,14 +208,14 @@ export async function sendTelegramMessage(
           );
           return false;
         case "Forbidden: user is deactivated":
-          umamiLogger({
+          await umamiLogger({
             event: "/user-deactivated",
             messageApp: "Telegram"
           });
           await deleteUserAndCleanupByIdentifier("Telegram", chatId);
           return false;
         case "Too many requests":
-          umamiLogger({
+          await umamiLogger({
             event: "/message-fail-too-many-requests",
             messageApp: "Telegram"
           });

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -181,7 +181,7 @@ export async function sendWhatsAppMessage(
   const umamiLogger: UmamiLogger =
     options?.useAsyncUmamiLog === true ? umami.logAsync : umami.log;
   if (retryNumber > 5) {
-    umamiLogger({
+    await umamiLogger({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: "WhatsApp"
     });
@@ -272,7 +272,7 @@ export async function sendWhatsAppMessage(
           case 130429:
           case 131048:
           case 131056:
-            umamiLogger({
+            await umamiLogger({
               event: "/message-fail-too-many-requests",
               messageApp: "WhatsApp"
             });
@@ -288,7 +288,7 @@ export async function sendWhatsAppMessage(
             );
 
           case 131008: // user blocked the bot
-            umamiLogger({
+            await umamiLogger({
               event: "/user-blocked-joel",
               messageApp: "WhatsApp"
             });
@@ -299,7 +299,7 @@ export async function sendWhatsAppMessage(
             break;
           case 131026: // user not on WhatsApp
           case 131030:
-            umamiLogger({
+            await umamiLogger({
               event: "/user-deactivated",
               messageApp: "WhatsApp"
             });
@@ -310,7 +310,7 @@ export async function sendWhatsAppMessage(
         }
         return false;
       }
-      umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
+      await umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
 
       if (burstMode || (i == mArr.length - 1 && options?.separateMenuMessage)) {
         // prevent hitting the WH API rate limit
@@ -344,7 +344,7 @@ export async function sendWhatsAppMessage(
         return false;
       }
       numberMessageBurst += 1;
-      umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
+      await umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
     }
 
     // make up for the cooldown delay borrowed in the burst mode

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -5,7 +5,7 @@ import {
   MessageSendingOptionsInternal,
   recordSuccessfulDelivery
 } from "./Session.ts";
-import umami, { UmamiEvent } from "../utils/umami.ts";
+import umami, { UmamiEvent, UmamiLogger } from "../utils/umami.ts";
 import { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
 import { ServerMessageResponse } from "whatsapp-api-js/types";
 import { ErrorMessages } from "./ErrorMessages.ts";
@@ -178,8 +178,10 @@ export async function sendWhatsAppMessage(
   options?: MessageSendingOptionsInternal,
   retryNumber = 0
 ): Promise<boolean> {
+  const umamiLogger: UmamiLogger =
+    options?.useAsyncUmamiLog === true ? umami.logAsync : umami.log;
   if (retryNumber > 5) {
-    umami.log({
+    umamiLogger({
       event: "/message-fail-too-many-requests-aborted",
       messageApp: "WhatsApp"
     });
@@ -270,7 +272,7 @@ export async function sendWhatsAppMessage(
           case 130429:
           case 131048:
           case 131056:
-            umami.log({
+            umamiLogger({
               event: "/message-fail-too-many-requests",
               messageApp: "WhatsApp"
             });
@@ -286,7 +288,7 @@ export async function sendWhatsAppMessage(
             );
 
           case 131008: // user blocked the bot
-            umami.log({
+            umamiLogger({
               event: "/user-blocked-joel",
               messageApp: "WhatsApp"
             });
@@ -297,7 +299,7 @@ export async function sendWhatsAppMessage(
             break;
           case 131026: // user not on WhatsApp
           case 131030:
-            umami.log({
+            umamiLogger({
               event: "/user-deactivated",
               messageApp: "WhatsApp"
             });
@@ -308,7 +310,7 @@ export async function sendWhatsAppMessage(
         }
         return false;
       }
-      umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
+      umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
 
       if (burstMode || (i == mArr.length - 1 && options?.separateMenuMessage)) {
         // prevent hitting the WH API rate limit
@@ -342,7 +344,7 @@ export async function sendWhatsAppMessage(
         return false;
       }
       numberMessageBurst += 1;
-      umami.log({ event: "/message-sent", messageApp: "WhatsApp" });
+      umamiLogger({ event: "/message-sent", messageApp: "WhatsApp" });
     }
 
     // make up for the cooldown delay borrowed in the burst mode

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -155,7 +155,8 @@ async function sendAlertStringUpdate(
 
   const messageAppsOptionsApp = {
     ...messageAppsOptions,
-    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+    separateMenuMessage: userInfo.messageApp === "WhatsApp",
+    useAsyncUmamiLog: true
   };
 
   const messageSent = await sendMessage(

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -173,7 +173,7 @@ async function sendAlertStringUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  umami.log({
+  await umami.logAsync({
     event: "/notification-update-meta",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -273,7 +273,7 @@ async function sendTagUpdates(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  umami.log({
+  await umami.logAsync({
     event: "/notification-update-function",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -255,7 +255,8 @@ async function sendTagUpdates(
 
   const messageAppsOptionsApp = {
     ...messageAppsOptions,
-    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+    separateMenuMessage: userInfo.messageApp === "WhatsApp",
+    useAsyncUmamiLog: true
   };
 
   const messageSent = await sendMessage(

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -227,7 +227,7 @@ async function sendNameMentionUpdates(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  umami.log({
+  await umami.logAsync({
     event: "/notification-update-name",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -209,7 +209,8 @@ async function sendNameMentionUpdates(
 
   const messageAppsOptionsApp = {
     ...messageAppsOptions,
-    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+    separateMenuMessage: userInfo.messageApp === "WhatsApp",
+    useAsyncUmamiLog: true
   };
 
   const messageSent = await sendMessage(

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -282,7 +282,7 @@ async function sendOrganisationUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  umami.log({
+  await umami.logAsync({
     event: "/notification-update-organisation",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -264,7 +264,8 @@ async function sendOrganisationUpdate(
 
   const messageAppsOptionsApp = {
     ...messageAppsOptions,
-    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+    separateMenuMessage: userInfo.messageApp === "WhatsApp",
+    useAsyncUmamiLog: true
   };
 
   const messageSent = await sendMessage(

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -249,7 +249,8 @@ async function sendPeopleUpdate(
 
   const messageAppsOptionsApp = {
     ...messageAppsOptions,
-    separateMenuMessage: userInfo.messageApp === "WhatsApp"
+    separateMenuMessage: userInfo.messageApp === "WhatsApp",
+    useAsyncUmamiLog: true
   };
 
   const messageSent = await sendMessage(

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -267,7 +267,7 @@ async function sendPeopleUpdate(
       .reduce((total: number, value) => total + value.length, 0)
   };
 
-  umami.log({
+  await umami.logAsync({
     event: "/notification-update-people",
     messageApp: userInfo.messageApp,
     notificationData: notifData

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -125,7 +125,7 @@ async function saveNewMetaPublications(
 
   if (newRecords.length > 0) {
     await Publication.insertMany(newRecords, { ordered: false });
-    umami.log({
+    await umami.logAsync({
       event: "/publication-added",
       payload: { nb: newRecords.length }
     });
@@ -231,7 +231,7 @@ export async function runNotificationProcess(
   }
 
   for (const appType of targetApps) {
-    umami.log({
+    await umami.logAsync({
       event: "/notification-process-completed",
       messageApp: appType
     });

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -64,14 +64,16 @@ const logInternal = async (args: UmamiLogArgs) => {
   });
 };
 
-export const log = (args: UmamiLogArgs) => {
+export const log: UmamiLogger = (args: UmamiLogArgs) => {
   // Schedule the whole logging routine to keep callers non-blocking.
   setImmediate(() => {
     void logInternal(args);
   });
 };
 
-export const logAsync = async (args: UmamiLogArgs): Promise<void> => {
+export const logAsync: UmamiLogger = async (
+  args: UmamiLogArgs
+): Promise<void> => {
   await logInternal(args);
 };
 

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -7,7 +7,7 @@ export interface UmamiNotificationData {
   total_records_nb: number;
 }
 
-export type UmamiLogger = (args: UmamiLogArgs) => Promise<void> | void;
+export type UmamiLogger = (args: UmamiLogArgs) => Promise<void>;
 
 export interface UmamiLogArgs {
   event: UmamiEvent;
@@ -64,16 +64,15 @@ const logInternal = async (args: UmamiLogArgs) => {
   });
 };
 
-export const log: UmamiLogger = (args: UmamiLogArgs) => {
+export const log: UmamiLogger = async (args: UmamiLogArgs) =>
   // Schedule the whole logging routine to keep callers non-blocking.
-  setImmediate(() => {
-    void logInternal(args);
+  await new Promise((resolve) => {
+    setImmediate(() => {
+      void logInternal(args).finally(resolve);
+    });
   });
-};
 
-export const logAsync: UmamiLogger = async (
-  args: UmamiLogArgs
-): Promise<void> => {
+export const logAsync: UmamiLogger = async (args: UmamiLogArgs): Promise<void> => {
   await logInternal(args);
 };
 


### PR DESCRIPTION
## Summary
- add an awaitable `umami.logAsync` helper alongside the existing logger
- switch daily notification flows to use the async logger when recording events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938c194e7d0832dbe39536e00420fe2)