### PR TITLE
merge main

### DIFF
--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -645,8 +645,16 @@ async function checkReferenceInDb(
       dateSplit[1] - 1,
       dateSplit[2]
     );
+    // callJORFSearchMetaDay queries the API with the given date but filters by previousDay
+    // So we need to add 1 day to get publications with date === referenceDate
+    // Note: Date constructor handles day overflow correctly (e.g., Jan 32 → Feb 1)
+    const queryDate = new Date(
+      dateSplit[0],
+      dateSplit[1] - 1,
+      dateSplit[2] + 1
+    );
     const publicationItem = await callJORFSearchMetaDay(
-      referenceDate,
+      queryDate,
       [messageApp],
       0,
       false


### PR DESCRIPTION
The callJORFSearchMetaDay function queries the API with a given date but filters results by the previous day. This is because the JORFSearch meta API returns publications for the day before the query date.

When checkReferenceInDb is called with a publication date (e.g., 2026-02-01), it needs to query with the next day (2026-02-02) so that the filter by previousDay (2026-02-01) matches the publication.