### PR TITLE
Sync main with upstream (fabrahaingo/joel)

### DIFF
--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -27,11 +27,11 @@ export const triggerPendingNotifications = async (
       await session.sendMessage("Veuillez ajouter un suivi.");
       return;
     }
-    if (session.user.waitingReengagement)
-      await User.updateOne(
-        { _id: session.user._id },
-        { $set: { waitingReengagement: false } }
-      );
+    // Note: the re-engagement flag is cleared atomically together with pending +
+    // reminder count in the single $set below, after notifyAllFollows succeeds.
+    // Clearing it separately up-front left flag:false but pending intact whenever
+    // notifyAllFollows threw. The inbound reset in handleIncomingMessage already
+    // clears the flag on the normal path.
     if (session.user.pendingNotifications.length == 0) {
       await session.sendMessage("Aucune notification en attente.");
       return;

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -58,6 +58,11 @@ export const WHATSAPP_NEAR_MISS_WINDOW_MS =
 export const REENGAGEMENT_REMINDER_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 export const MAX_REENGAGEMENT_REMINDERS = 8;
 
+// Hard ceiling on reminders sent per sweep run. Caps the cost/throughput spike
+// when a large backlog of pending users all come due at once (e.g. first run
+// after deploy); the rest roll over to the next daily sweep, oldest pending first.
+export const REENGAGEMENT_MAX_SENDS_PER_SWEEP = 500;
+
 export const TEMPLATE_MESSAGE_COST_EUROS = 0.0248;
 
 const WhatsAppMessageApp: MessageApp = "WhatsApp";

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -547,7 +547,9 @@ export async function handleWhatsAppAPIErrors(
     chatId: chatId
   }).lean();
   switch (error.errorCode) {
-    // If rate limit exceeded, retry after 4^(numberRetry) seconds
+    // Transient Meta-side outage (#2 Service temporarily unavailable) and rate
+    // limits: retry after 4^(numberRetry) seconds
+    case 2:
     case 4:
     case 80007:
     case 130429:
@@ -559,6 +561,11 @@ export async function handleWhatsAppAPIErrors(
             event: "/message-fail-too-many-requests-aborted",
             messageApp: "WhatsApp"
           });
+          await logError(
+            "WhatsApp",
+            `WH API error ${String(error.errorCode)} aborted after ${String(MAX_MESSAGE_RETRY)} retries in ${callerFunctionLabel} to ${chatId}`,
+            error.rawError ?? undefined
+          );
           return false;
         }
         await umamiLogger({

--- a/notifications/reengagementReminderSweep.ts
+++ b/notifications/reengagementReminderSweep.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
-import User from "../models/User.ts";
+import User, { MAX_PENDING_AGE_MS } from "../models/User.ts";
 import { IUser } from "../types.ts";
+import type { QueryFilter } from "mongoose";
 import {
   ExtendedMiniUserInfo,
   ExternalMessageOptions
@@ -9,6 +10,7 @@ import {
   FINAL_NOTIFICATION_TEMPLATE,
   MAX_REENGAGEMENT_REMINDERS,
   NOTIFICATION_TEMPLATE,
+  REENGAGEMENT_MAX_SENDS_PER_SWEEP,
   REENGAGEMENT_REMINDER_INTERVAL_MS,
   sendWhatsAppTemplate,
   TEMPLATE_MESSAGE_COST_EUROS,
@@ -43,42 +45,88 @@ export async function runReengagementReminderSweep(
   const reminderCutoff = new Date(
     Date.now() - REENGAGEMENT_REMINDER_INTERVAL_MS
   );
+  const pendingAgeCutoff = new Date(Date.now() - MAX_PENDING_AGE_MS);
 
-  const dueUsers: IUser[] = await User.find(
+  // A user has "live" pending only if at least one batch holds real, current
+  // records: non-empty source_ids AND either an exempt type (people/name, never
+  // aged out) or recent enough that the capped age-out hasn't dropped it. Gating
+  // on mere array presence let legacy users sitting on empty/stale pending qualify
+  // forever, which blasted the whole backlog on the first sweep.
+  const livePendingClause: QueryFilter<IUser> = {
+    pendingNotifications: {
+      $elemMatch: {
+        "source_ids.0": { $exists: true },
+        $or: [
+          { notificationType: { $in: ["people", "name"] } },
+          { insertDate: { $gte: pendingAgeCutoff } }
+        ]
+      }
+    }
+  };
+
+  // Self-heal: drain the legacy backlog without a migration. Any user still
+  // flagged waiting but with no live pending (empty or fully stale) can never be
+  // legitimately reminded, so clear the flag/cycle so it stops matching future
+  // sweeps and never fires a false reminder.
+  const healed = await User.updateMany(
     {
       messageApp: "WhatsApp",
-      status: "active",
       waitingReengagement: true,
-      "pendingNotifications.0": { $exists: true },
-      $and: [
-        {
-          $or: [
-            { reengagementReminderCount: { $exists: false } },
-            { reengagementReminderCount: { $lt: MAX_REENGAGEMENT_REMINDERS } }
-          ]
-        },
-        {
-          $or: [
-            { lastReengagementSentAt: { $exists: false } },
-            { lastReengagementSentAt: { $lte: reminderCutoff } }
-          ]
-        }
-      ]
+      $nor: [livePendingClause]
     },
-    {
-      chatId: 1,
-      roomId: 1,
-      status: 1,
-      lastEngagementAt: 1,
-      waitingReengagement: 1,
-      reengagementReminderCount: 1
-    }
-  ).lean();
+    { $set: { waitingReengagement: false, reengagementReminderCount: 0 } }
+  );
+  if (healed.modifiedCount > 0) {
+    console.log(
+      `Re-engagement reminder sweep: cleared ${String(healed.modifiedCount)} stale waiting flag(s).`
+    );
+  }
 
-  if (dueUsers.length === 0) return;
+  const dueFilter: QueryFilter<IUser> = {
+    messageApp: "WhatsApp",
+    status: "active",
+    waitingReengagement: true,
+    ...livePendingClause,
+    $and: [
+      {
+        $or: [
+          { reengagementReminderCount: { $exists: false } },
+          { reengagementReminderCount: { $lt: MAX_REENGAGEMENT_REMINDERS } }
+        ]
+      },
+      {
+        $or: [
+          { lastReengagementSentAt: { $exists: false } },
+          { lastReengagementSentAt: { $lte: reminderCutoff } }
+        ]
+      }
+    ]
+  };
 
+  const dueCount = await User.countDocuments(dueFilter);
+  if (dueCount === 0) return;
+
+  // Cap sends per run and serve least-recently-reminded first (missing
+  // lastReengagementSentAt sorts first), so a large backlog is staggered across
+  // daily sweeps instead of blasted at once. Overflow rolls over to the next run.
+  const dueUsers: IUser[] = await User.find(dueFilter, {
+    chatId: 1,
+    roomId: 1,
+    status: 1,
+    lastEngagementAt: 1,
+    waitingReengagement: 1,
+    reengagementReminderCount: 1
+  })
+    .sort({ lastReengagementSentAt: 1 })
+    .limit(REENGAGEMENT_MAX_SENDS_PER_SWEEP)
+    .lean();
+
+  const deferred = dueCount - dueUsers.length;
   console.log(
-    `Re-engagement reminder sweep: ${String(dueUsers.length)} WhatsApp user(s) due.`
+    `Re-engagement reminder sweep: ${String(dueUsers.length)} WhatsApp user(s) due` +
+      (deferred > 0
+        ? `, ${String(deferred)} deferred to next sweep (cap ${String(REENGAGEMENT_MAX_SENDS_PER_SWEEP)}).`
+        : ".")
   );
 
   const limit = pLimit(WHATSAPP_API_SENDING_CONCURRENCY);

--- a/tests/09.reengagement.sweep.test.ts
+++ b/tests/09.reengagement.sweep.test.ts
@@ -28,6 +28,21 @@ import {
 } from "../entities/WhatsAppSession.ts";
 
 const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+const NINETY_ONE_DAYS_MS = 91 * 24 * 60 * 60 * 1000;
+
+const pendingBatch = (overrides: Record<string, unknown> = {}) => ({
+  notificationType: "function",
+  source_ids: ["JORFTEXT000001"],
+  insertDate: new Date(),
+  items_nb: 1,
+  ...overrides
+});
+
+const isWaiting = async (chatId: string): Promise<boolean> => {
+  const u = await User.findOne({ chatId }, { waitingReengagement: 1 }).lean();
+  if (u == null) throw new Error(`user ${chatId} not found`);
+  return u.waitingReengagement;
+};
 
 const fakeOptions = {
   whatsAppAPI: {} as unknown
@@ -80,6 +95,61 @@ describe("runReengagementReminderSweep", () => {
     await runReengagementReminderSweep(fakeOptions);
 
     expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sentChatIds()).toEqual([due.chatId]);
+  });
+
+  it("excludes users whose only pending is a stale capped batch", async () => {
+    await createWAUser({
+      pendingNotifications: [
+        pendingBatch({ insertDate: new Date(Date.now() - NINETY_ONE_DAYS_MS) })
+      ]
+    });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("still reminds when stale pending is an exempt people/name batch", async () => {
+    const due = await createWAUser({
+      pendingNotifications: [
+        pendingBatch({
+          notificationType: "people",
+          insertDate: new Date(Date.now() - NINETY_ONE_DAYS_MS)
+        })
+      ]
+    });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sentChatIds()).toEqual([due.chatId]);
+  });
+
+  it("excludes batches with no source_ids", async () => {
+    await createWAUser({
+      pendingNotifications: [pendingBatch({ source_ids: [], items_nb: 0 })]
+    });
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("self-heals: clears the waiting flag on users with no live pending", async () => {
+    const empty = await createWAUser({ pendingNotifications: [] });
+    const stale = await createWAUser({
+      pendingNotifications: [
+        pendingBatch({ insertDate: new Date(Date.now() - NINETY_ONE_DAYS_MS) })
+      ]
+    });
+    const due = await createWAUser();
+
+    await runReengagementReminderSweep(fakeOptions);
+
+    expect(await isWaiting(empty.chatId)).toBe(false);
+    expect(await isWaiting(stale.chatId)).toBe(false);
+    // A genuinely-due user keeps the flag (the send loop drives its lifecycle).
+    expect(await isWaiting(due.chatId)).toBe(true);
     expect(sentChatIds()).toEqual([due.chatId]);
   });
 

--- a/utils/JORFSearch.utils.ts
+++ b/utils/JORFSearch.utils.ts
@@ -569,7 +569,7 @@ export async function searchOrganisationWikidataId(
     if (wikidataIds_raw.length == 0) return []; // prevents unnecessary jorf event
 
     url = encodeURI(
-      `https://jorfsearch.steinertriples.ch/wikidata_id_to_name?ids[]=${wikidataIds_raw.map((o) => o.id).join("&ids[]=")}`
+      `https://jorfsearch.steinertriples.ch/wikidata/contains?ids[]=${wikidataIds_raw.map((o) => o.id).join("&ids[]=")}`
     );
     return await jorfAxios
       .get<{ name: string; id: WikidataId }[] | null>(url)


### PR DESCRIPTION
Fast-forward/merge of upstream `fabrahaingo/joel@main` into fork `main`.

Brings in 4 upstream commits the fork was missing:
- fix(whatsapp): gate re-engagement sweep on live pending records (#302)
- fix(whatsapp): retry transient API error #2 instead of dropping message
- fix(jorfsearch): use renamed wikidata/contains endpoint

No original fork changes discarded; merge preserves the prior `#211` sync merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)