### PR TITLE
sync: upstream debug:notify:prod (#303)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start-wh:prod": "node dist/apps/whatsAppApp.js",
     "start-si:prod": "node dist/apps/signalApp.js",
     "debug:notify": "tsx scripts/testDebugNotification.ts",
+    "debug:notify:prod": "node dist/scripts/testDebugNotification.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "security:audit": "npm audit --omit=dev --audit-level=high",


### PR DESCRIPTION
@
Sync DanyPM/main with upstream fabrahaingo/main after merging fabrahaingo#303.

Brings in `debug:notify:prod` npm script (`node dist/scripts/testDebugNotification.js`) so the debug notification test runs inside the production Docker container, where only `dist/` ships.

Diff: package.json +1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@