### PR TITLE
sync: upstream main 2026-06-23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn.lock
 dist/
 /matrix/
 coverage-summary.json
+/coverage/

--- a/commands/triggerPendingNotifications.ts
+++ b/commands/triggerPendingNotifications.ts
@@ -111,6 +111,9 @@ export const triggerPendingNotifications = async (
       candidateJORFPublications,
       [session.messageApp],
       session.extractMessageAppsOptions(),
+      // Immediate re-engagement trigger: window clock is now. (forceWHMessages
+      // below skips the window check anyway, but the param is required.)
+      new Date(),
       [session.user._id],
       true
     );

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -43,7 +43,17 @@ export const WHATSAPP_API_SENDING_CONCURRENCY = 80; // 80 messages per second gl
 export const WHATSAPP_API_VERSION = "v24.0";
 
 // MARGIN RELATIVE TO 24h REENGAGEMENT WINDOW
+// Safety buffer before the real 24h limit: only needs to cover the
+// snapshot->actual-send latency for an edge-first user plus WhatsApp API time.
 export const WHATSAPP_REENGAGEMENT_MARGIN_MINS = 5; // 5 mins
+
+// Per-day advance applied by the daily scheduler to keep a user who interacted
+// yesterday inside their 24h window today (see notificationScheduler.ts). Kept
+// separate from the cutoff margin above so each can be tuned independently:
+// historically both were the same constant, which is why margin == step ==
+// process-latency all read as "5 min". Keep >= margin so the chained window
+// never closes before the next run.
+export const WHATSAPP_SHIFT_STEP_MINS = 5; // 5 mins
 
 // 24h - MARGIN_MINS
 export const WHATSAPP_REENGAGEMENT_TIMEOUT_WITH_MARGIN_MS =

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,10 @@ import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended"
 import prettierConfig from "eslint-config-prettier";
 
 export default defineConfig(
+  // Never lint build/coverage output. `npm run build` (tsc) emits compiled JS
+  // into dist/, which the type-aware parser can't resolve and which isn't ours
+  // to lint; without this, building before a commit breaks the lint hook.
+  { ignores: ["dist/**", "coverage/**"] },
   eslint.configs.recommended,
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -32,6 +32,9 @@ export async function notifyAlertStringUpdates(
   metaRecords: JORFSearchPublication[],
   enabledApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // Single clock snapshotted at process start, threaded through every handler so
+  // the 24h-window decision can't drift as the (slow) run progresses.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -115,7 +118,7 @@ export async function notifyAlertStringUpdates(
   await dispatchTasksToMessageApps<string, JORFSearchPublication>(
     userUpdateTasks,
     async (task) => {
-      const now = new Date();
+      const now = windowNow;
 
       const reengagementExpired =
         now.getTime() - task.userInfo.lastEngagementAt.getTime() >

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -88,6 +88,9 @@ export async function notifyFunctionTagsUpdates(
   updatedRecords: JORFSearchItem[],
   enabledApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // Single clock snapshotted at process start, threaded through every handler so
+  // the 24h-window decision can't drift as the (slow) run progresses.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -189,7 +192,7 @@ export async function notifyFunctionTagsUpdates(
   await dispatchTasksToMessageApps<FunctionTags>(
     userUpdateTasks,
     async (task) => {
-      const now = new Date();
+      const now = windowNow;
 
       const reengagementExpired =
         now.getTime() - task.userInfo.lastEngagementAt.getTime() >

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -92,6 +92,9 @@ export async function notifyNameMentionUpdates(
   updatedRecords: JORFSearchItem[],
   enabledApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // Single clock snapshotted at process start, threaded through every handler so
+  // the 24h-window decision can't drift as the (slow) run progresses.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -191,7 +194,7 @@ export async function notifyNameMentionUpdates(
   if (userUpdateTasks.length === 0) return;
 
   await dispatchTasksToMessageApps<string>(userUpdateTasks, async (task) => {
-    const now = new Date();
+    const now = windowNow;
 
     const reengagementExpired =
       now.getTime() - task.userInfo.lastEngagementAt.getTime() >

--- a/notifications/notificationDispatch.ts
+++ b/notifications/notificationDispatch.ts
@@ -50,8 +50,21 @@ export async function dispatchTasksToMessageApps<T, R = JORFSearchItem>(
   const appPromises = [...tasksByMessageApp.keys()].map(async (messageApp) => {
     const appTasks = tasksByMessageApp.get(messageApp) ?? [];
 
-    // this ensures coherent size within batches, so they don't wait too much for each other
-    appTasks.sort((a, b) => b.recordCount - a.recordCount);
+    if (messageApp === "WhatsApp") {
+      // Edge-first: send the users closest to their 24h re-engagement window edge
+      // first, so the slow run reaches them in its first seconds and they keep the
+      // benefit of the scheduler's day-of-week start-advance instead of losing it to
+      // queue latency. Record count is only a tiebreaker here. (lastEngagementAt asc)
+      appTasks.sort(
+        (a, b) =>
+          a.userInfo.lastEngagementAt.getTime() -
+            b.userInfo.lastEngagementAt.getTime() ||
+          b.recordCount - a.recordCount
+      );
+    } else {
+      // this ensures coherent size within batches, so they don't wait too much for each other
+      appTasks.sort((a, b) => b.recordCount - a.recordCount);
+    }
 
     const app_concurrency_limit =
       concurrencyLimitByMessageApp.get(messageApp) ?? 1;

--- a/notifications/notificationScheduler.ts
+++ b/notifications/notificationScheduler.ts
@@ -4,7 +4,7 @@ import { runNotificationProcess } from "./runNotificationProcess.ts";
 import { ExternalMessageOptions } from "../entities/Session.ts";
 import { logError, logWarning } from "../utils/debugLogger.ts";
 import { dateToString, formatDuration } from "../utils/date.utils.ts";
-import { WHATSAPP_REENGAGEMENT_MARGIN_MINS } from "../entities/WhatsAppSession.ts";
+import { WHATSAPP_SHIFT_STEP_MINS } from "../entities/WhatsAppSession.ts";
 
 interface DailyTime {
   hour: number;
@@ -33,12 +33,12 @@ function parseDailyTime(value: string): DailyTime {
   return { hour, minute };
 }
 
-function computeNextOccurrence(
+export function computeNextOccurrence(
   { hour, minute }: DailyTime,
-  messageApps: MessageApp[]
+  messageApps: MessageApp[],
+  // Injectable for tests; defaults to wall-clock in production.
+  now: Date = new Date()
 ): Date {
-  const now = new Date();
-
   const currentDayString = dateToString(now, "YMD");
 
   const nextWithoutShift = new Date(now);
@@ -63,8 +63,7 @@ function computeNextOccurrence(
         `Computed negative timeShiftIndex: ${String(timeShiftIndex)}`
       );
     }
-    timeShiftMs =
-      timeShiftIndex * WHATSAPP_REENGAGEMENT_MARGIN_MINS * 60 * 1000;
+    timeShiftMs = timeShiftIndex * WHATSAPP_SHIFT_STEP_MINS * 60 * 1000;
     // Tuesday : expected time
     // Wednesday: expected time - 1*MARGIN
     // Thursday: expected time - 2*MARGIN

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -69,6 +69,9 @@ export async function notifyOrganisationsUpdates(
   allUpdatedRecords: JORFSearchItem[],
   enabledApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // Single clock snapshotted at process start, threaded through every handler so
+  // the 24h-window decision can't drift as the (slow) run progresses.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -193,7 +196,7 @@ export async function notifyOrganisationsUpdates(
   await dispatchTasksToMessageApps<WikidataId>(
     userUpdateTasks,
     async (task) => {
-      const now = new Date();
+      const now = windowNow;
 
       const reengagementExpired =
         now.getTime() - task.userInfo.lastEngagementAt.getTime() >

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -55,6 +55,9 @@ export async function notifyPeopleUpdates(
   updatedRecords: JORFSearchItem[],
   enabledApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // Single clock snapshotted at process start, threaded through every handler so
+  // the 24h-window decision can't drift as the (slow) run progresses.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -200,7 +203,7 @@ export async function notifyPeopleUpdates(
   if (userUpdateTasks.length === 0) return;
 
   await dispatchTasksToMessageApps<string>(userUpdateTasks, async (task) => {
-    const now = new Date();
+    const now = windowNow;
 
     const reengagementExpired =
       now.getTime() - task.userInfo.lastEngagementAt.getTime() >

--- a/notifications/runNotificationProcess.ts
+++ b/notifications/runNotificationProcess.ts
@@ -127,7 +127,9 @@ export async function runNotificationProcess(
       JORFAllRecordsFromDate,
       JORFMetaRecordsFromDate,
       targetApps,
-      messageAppsOptions
+      messageAppsOptions,
+      // `start` is the process-start snapshot; reuse it as the single window clock.
+      start
     );
 
     // Weekly reminder for WhatsApp users sitting on pending notifications.
@@ -175,6 +177,10 @@ export async function notifyAllFollows(
   JORFMetaRecordsFromDate: JORFSearchPublication[],
   targetApps: MessageApp[],
   messageAppsOptions: ExternalMessageOptions,
+  // One clock for the whole run: every handler judges the 24h window against the
+  // same instant, so a user can't be in-window for handler 1 and expired by
+  // handler 5 just because the run is slow.
+  windowNow: Date,
   userIds?: Types.ObjectId[],
   forceWHMessages = false
 ) {
@@ -183,6 +189,7 @@ export async function notifyAllFollows(
       JORFAllRecordsFromDate,
       targetApps,
       messageAppsOptions,
+      windowNow,
       userIds,
       forceWHMessages
     );
@@ -191,6 +198,7 @@ export async function notifyAllFollows(
       JORFAllRecordsFromDate,
       targetApps,
       messageAppsOptions,
+      windowNow,
       userIds,
       forceWHMessages
     );
@@ -199,6 +207,7 @@ export async function notifyAllFollows(
       JORFAllRecordsFromDate,
       targetApps,
       messageAppsOptions,
+      windowNow,
       userIds,
       forceWHMessages
     );
@@ -206,7 +215,8 @@ export async function notifyAllFollows(
     await notifyNameMentionUpdates(
       JORFAllRecordsFromDate,
       targetApps,
-      messageAppsOptions
+      messageAppsOptions,
+      windowNow
     );
   }
 
@@ -214,7 +224,8 @@ export async function notifyAllFollows(
     await notifyAlertStringUpdates(
       JORFMetaRecordsFromDate,
       targetApps,
-      messageAppsOptions
+      messageAppsOptions,
+      windowNow
     );
   }
 }

--- a/tests/10.notificationDispatch.test.ts
+++ b/tests/10.notificationDispatch.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { Types } from "mongoose";
+import {
+  dispatchTasksToMessageApps,
+  NotificationTask
+} from "../notifications/notificationDispatch.ts";
+import type { ExtendedMiniUserInfo } from "../entities/Session.ts";
+import type { MessageApp } from "../types.ts";
+
+// Pure ordering test for the dispatcher: no DB, no network. We feed tasks and a
+// taskFunction that just records the order in which it was invoked per app.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const makeTask = (
+  label: string,
+  messageApp: MessageApp,
+  lastEngagementMsAgo: number,
+  recordCount: number
+): NotificationTask<string> => {
+  const userInfo: ExtendedMiniUserInfo = {
+    messageApp,
+    chatId: label,
+    status: "active",
+    hasAccount: true,
+    waitingReengagement: false,
+    lastEngagementAt: new Date(Date.now() - lastEngagementMsAgo)
+  };
+  return {
+    userId: new Types.ObjectId(),
+    userInfo,
+    updatedRecordsMap: new Map<string, never[]>(),
+    recordCount
+  };
+};
+
+// Run the dispatcher and return the chatId labels in the order they were sent,
+// grouped by app (apps run concurrently, but order *within* an app is what we assert).
+const dispatchAndRecord = async (
+  tasks: NotificationTask<string>[]
+): Promise<Map<MessageApp, string[]>> => {
+  const orderByApp = new Map<MessageApp, string[]>();
+  await dispatchTasksToMessageApps<string>(tasks, async (task) => {
+    const app = task.userInfo.messageApp;
+    orderByApp.set(
+      app,
+      (orderByApp.get(app) ?? []).concat(task.userInfo.chatId)
+    );
+    await Promise.resolve();
+  });
+  return orderByApp;
+};
+
+describe("dispatchTasksToMessageApps — WhatsApp edge-first ordering", () => {
+  it("sends WhatsApp users closest to their 24h window edge first", async () => {
+    // older lastEngagementAt == closer to expiry == must go first
+    const tasks = [
+      makeTask("wh-fresh", "WhatsApp", 1 * 60 * 60 * 1000, 50), // 1h ago
+      makeTask("wh-edge", "WhatsApp", DAY_MS - 5 * 60 * 1000, 1), // ~at edge
+      makeTask("wh-mid", "WhatsApp", 12 * 60 * 60 * 1000, 99) // 12h ago
+    ];
+
+    const order = await dispatchAndRecord(tasks);
+
+    expect(order.get("WhatsApp")).toEqual(["wh-edge", "wh-mid", "wh-fresh"]);
+  });
+
+  it("uses record count only as a tiebreaker when window edges are equal", async () => {
+    const tasks = [
+      makeTask("wh-small", "WhatsApp", DAY_MS, 1),
+      makeTask("wh-big", "WhatsApp", DAY_MS, 100)
+    ];
+
+    const order = await dispatchAndRecord(tasks);
+
+    // equal lastEngagementAt -> larger record count first
+    expect(order.get("WhatsApp")).toEqual(["wh-big", "wh-small"]);
+  });
+});
+
+describe("dispatchTasksToMessageApps — non-WhatsApp ordering unchanged", () => {
+  it("orders Telegram users by record count (largest first), ignoring window edge", async () => {
+    const tasks = [
+      makeTask("tg-edge-small", "Telegram", DAY_MS, 1), // nearest edge but smallest
+      makeTask("tg-big", "Telegram", 1 * 60 * 60 * 1000, 100),
+      makeTask("tg-mid", "Telegram", 2 * 60 * 60 * 1000, 50)
+    ];
+
+    const order = await dispatchAndRecord(tasks);
+
+    expect(order.get("Telegram")).toEqual([
+      "tg-big",
+      "tg-mid",
+      "tg-edge-small"
+    ]);
+  });
+
+  it("keeps each app's ordering independent when apps are mixed", async () => {
+    const tasks = [
+      makeTask("wh-fresh", "WhatsApp", 1 * 60 * 60 * 1000, 100),
+      makeTask("wh-edge", "WhatsApp", DAY_MS, 1),
+      makeTask("tg-small", "Telegram", DAY_MS, 1),
+      makeTask("tg-big", "Telegram", 1 * 60 * 60 * 1000, 100)
+    ];
+
+    const order = await dispatchAndRecord(tasks);
+
+    expect(order.get("WhatsApp")).toEqual(["wh-edge", "wh-fresh"]); // edge-first
+    expect(order.get("Telegram")).toEqual(["tg-big", "tg-small"]); // record-count
+  });
+});

--- a/tests/11.notification.window.test.ts
+++ b/tests/11.notification.window.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+
+// Spy the template sender so no real WhatsApp API / cooldown runs.
+const { sendSpy } = vi.hoisted(() => ({ sendSpy: vi.fn() }));
+
+vi.mock("../entities/WhatsAppSession.ts", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../entities/WhatsAppSession.ts")>();
+  return {
+    ...actual,
+    sendWhatsAppTemplate: (...args: unknown[]): Promise<boolean> =>
+      sendSpy(...args) as Promise<boolean>
+  };
+});
+
+const { umamiLogAsync } = vi.hoisted(() => ({ umamiLogAsync: vi.fn() }));
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: umamiLogAsync }
+}));
+
+import User, { USER_SCHEMA_VERSION } from "../models/User.ts";
+import type { ExternalMessageOptions } from "../entities/Session.ts";
+import type { JORFSearchItem } from "../entities/JORFSearchResponse.ts";
+import { FunctionTags } from "../entities/FunctionTags.ts";
+import { notifyFunctionTagsUpdates } from "../notifications/functionTagNotifications.ts";
+
+const TAG = FunctionTags.Ambassadeur; // "ambassadeur"
+const HOUR_MS = 60 * 60 * 1000;
+
+const fakeOptions = {
+  whatsAppAPI: {} as unknown
+} as ExternalMessageOptions;
+
+// A record carrying the followed function tag; only source_id / source_date /
+// the tag key are read on the expired path.
+const tagRecord = (): JORFSearchItem =>
+  ({
+    [TAG]: "ok",
+    source_id: "JORFTEXT000001",
+    source_date: "2026-06-20"
+  }) as unknown as JORFSearchItem;
+
+// Fresh WhatsApp user: by wall-clock they are well inside their 24h window, so
+// any expiry can only come from the injected windowNow.
+const createFreshWAUser = (lastEngagementAt: Date) =>
+  User.create({
+    chatId: "wh-window-" + Math.random().toString(36).slice(2),
+    messageApp: "WhatsApp",
+    schemaVersion: USER_SCHEMA_VERSION,
+    status: "active",
+    waitingReengagement: false,
+    lastEngagementAt,
+    followedFunctions: [
+      { functionTag: TAG, lastUpdate: new Date("2020-01-01") }
+    ]
+  });
+
+const nearMissLogged = (): boolean =>
+  umamiLogAsync.mock.calls.some(
+    (c) => (c[0] as { event?: string }).event === "/wh-reengagement-near-miss"
+  );
+
+describe("notifyFunctionTagsUpdates — windowNow drives the 24h decision", () => {
+  beforeEach(async () => {
+    if (!mongoose.connection.db)
+      throw new Error("MongoDB connection not established");
+    await mongoose.connection.db.dropDatabase();
+    sendSpy.mockReset();
+    sendSpy.mockResolvedValue(true);
+    umamiLogAsync.mockReset();
+    umamiLogAsync.mockResolvedValue(undefined);
+  });
+
+  it("expires a wall-clock-in-window user when windowNow is past the edge", async () => {
+    const lastEngagementAt = new Date(); // now -> in window by wall clock
+    const user = await createFreshWAUser(lastEngagementAt);
+
+    // 25h after engagement: only honoring windowNow (not Date.now()) makes this expired.
+    const windowNow = new Date(lastEngagementAt.getTime() + 25 * HOUR_MS);
+
+    await notifyFunctionTagsUpdates(
+      [tagRecord()],
+      ["WhatsApp"],
+      fakeOptions,
+      windowNow
+    );
+
+    // Re-engagement template fired -> the expiry decision used windowNow.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    const refreshed = await User.findById(user._id).lean();
+    if (refreshed == null) throw new Error("user not found");
+    expect(refreshed.waitingReengagement).toBe(true);
+    // Updates were stashed as pending instead of being sent in-window.
+    expect(refreshed.pendingNotifications.length).toBe(1);
+    expect(refreshed.pendingNotifications[0].notificationType).toBe("function");
+    expect(refreshed.pendingNotifications[0].source_ids).toContain(
+      "JORFTEXT000001"
+    );
+  });
+
+  it("logs a near-miss when windowNow is just past the edge (within the near-miss window)", async () => {
+    const lastEngagementAt = new Date();
+    await createFreshWAUser(lastEngagementAt);
+
+    // 24h10m: expired, but inside the 24h25m near-miss window.
+    const windowNow = new Date(
+      lastEngagementAt.getTime() + 24 * HOUR_MS + 10 * 60 * 1000
+    );
+
+    await notifyFunctionTagsUpdates(
+      [tagRecord()],
+      ["WhatsApp"],
+      fakeOptions,
+      windowNow
+    );
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(nearMissLogged()).toBe(true);
+  });
+
+  it("does not log a near-miss when windowNow is far past the edge", async () => {
+    const lastEngagementAt = new Date();
+    await createFreshWAUser(lastEngagementAt);
+
+    // 30h: expired and well beyond the near-miss window.
+    const windowNow = new Date(lastEngagementAt.getTime() + 30 * HOUR_MS);
+
+    await notifyFunctionTagsUpdates(
+      [tagRecord()],
+      ["WhatsApp"],
+      fakeOptions,
+      windowNow
+    );
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(nearMissLogged()).toBe(false);
+  });
+});

--- a/tests/12.notificationScheduler.test.ts
+++ b/tests/12.notificationScheduler.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { computeNextOccurrence } from "../notifications/notificationScheduler.ts";
+import { WHATSAPP_SHIFT_STEP_MINS } from "../entities/WhatsAppSession.ts";
+
+// `now` is injected at 05:00 local (<= 6am) so computeNextOccurrence schedules
+// the *same* calendar day at the configured time with no day-advance — isolating
+// the day-of-week shift, which is the only thing that differs between apps.
+const TIME = { hour: 9, minute: 0 };
+const at5am = (y: number, mIdx: number, d: number): Date =>
+  new Date(y, mIdx, d, 5, 0, 0, 0);
+
+const STEP_MS = WHATSAPP_SHIFT_STEP_MINS * 60 * 1000;
+
+describe("computeNextOccurrence — day-of-week shift", () => {
+  it("applies no shift for non-WhatsApp apps", () => {
+    const now = at5am(2026, 5, 24); // Wednesday
+    const next = computeNextOccurrence(TIME, ["Telegram"], now);
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getDate()).toBe(24);
+  });
+
+  // (weekday, expected shift-step index) per the scheduler's (getDay()+5)%7 rule.
+  const cases: [string, Date, number][] = [
+    ["Tuesday", at5am(2026, 5, 23), 0],
+    ["Wednesday", at5am(2026, 5, 24), 1],
+    ["Thursday", at5am(2026, 5, 25), 2],
+    ["Friday", at5am(2026, 5, 26), 3],
+    ["Saturday", at5am(2026, 5, 27), 4],
+    ["Sunday", at5am(2026, 5, 28), 5],
+    ["Monday", at5am(2026, 5, 22), 6]
+  ];
+
+  for (const [label, now, index] of cases) {
+    it(`advances WhatsApp by ${String(index)}*STEP on ${label}`, () => {
+      const base = computeNextOccurrence(TIME, ["Telegram"], now);
+      const wh = computeNextOccurrence(TIME, ["WhatsApp"], now);
+
+      // WhatsApp run is advanced earlier than the un-shifted base by index*step.
+      expect(base.getTime() - wh.getTime()).toBe(index * STEP_MS);
+    });
+  }
+
+  it("uses WHATSAPP_SHIFT_STEP_MINS (decoupled from the cutoff margin) as the step", () => {
+    const now = at5am(2026, 5, 22); // Monday -> index 6
+    const base = computeNextOccurrence(TIME, ["Telegram"], now);
+    const wh = computeNextOccurrence(TIME, ["WhatsApp"], now);
+    expect(base.getTime() - wh.getTime()).toBe(6 * STEP_MS);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    // Only run the TypeScript sources under tests/. Without this, a prior
+    // `tsc` build leaves compiled copies in dist/tests/*.test.js that vitest
+    // would also pick up — running every suite twice and racing the two copies
+    // on the shared in-memory MongoDB (dropDatabase wiping the other mid-test).
+    include: ["tests/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
     globalSetup: "./tests/globalSetup.ts",
     setupFiles: ["./tests/setupFile.ts"],
     fileParallelism: false, // == jest --runInBand (forces maxWorkers 1)


### PR DESCRIPTION
Sync DanyPM/joel `main` with upstream `fabrahaingo/joel` after merge of #304.

Brings in:
- fix(whatsapp): stop daily-run latency from forcing re-engagement near-misses
- test(notifications): dispatch/window/scheduler coverage + suite flakiness fix
- chore: gitignore coverage (upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)