### PR TITLE
sync: upstream main (WH send guard non-fatal #305)

### DIFF
--- a/entities/Session.ts
+++ b/entities/Session.ts
@@ -128,6 +128,11 @@ export interface MessageSendingOptionsInternal {
   separateMenuMessage?: boolean;
   useAsyncUmamiLog?: boolean;
   hasAccount?: boolean;
+  // Single run-wide clock for the WhatsApp re-engagement guard. When set (daily
+  // notification path), the guard judges the 24h window against the same instant
+  // the handler used to route free-message-vs-template, so the two can't disagree
+  // mid-run. Left undefined on interactive replies → guard uses new Date().
+  windowNow?: Date;
 }
 
 export interface MessageSendingOptionsExternal {
@@ -141,6 +146,9 @@ export interface MessageSendingOptionsExternal {
   separateMenuMessage?: boolean;
   useAsyncUmamiLog: boolean;
   hasAccount: boolean;
+  // See MessageSendingOptionsInternal.windowNow — passed through sendMessage to
+  // the WhatsApp guard by the notification path.
+  windowNow?: Date;
 }
 
 export interface MiniUserInfo {

--- a/entities/WhatsAppSession.ts
+++ b/entities/WhatsAppSession.ts
@@ -45,6 +45,10 @@ export const WHATSAPP_API_VERSION = "v24.0";
 // MARGIN RELATIVE TO 24h REENGAGEMENT WINDOW
 // Safety buffer before the real 24h limit: only needs to cover the
 // snapshot->actual-send latency for an edge-first user plus WhatsApp API time.
+// INVARIANT: margin >= max(windowNow snapshot -> actual send latency). The guard
+// decides on the run-start snapshot; the real send happens up to one run-length
+// later, so the margin must cover that gap to keep real sends < 24h (no WH error
+// 131047). Keeping NOTIFICATIONS_SHIFT_DAYS small bounds the run length here.
 export const WHATSAPP_REENGAGEMENT_MARGIN_MINS = 5; // 5 mins
 
 // Per-day advance applied by the daily scheduler to keep a user who interacted
@@ -235,14 +239,21 @@ export async function sendWhatsAppMessage(
   options: MessageSendingOptionsInternal,
   retryNumber = 0
 ): Promise<boolean> {
-  const now = new Date();
+  // Judge the window against the run-wide snapshot when the notification path
+  // supplies one, so this guard agrees with the routing decision the handler
+  // already made on the same instant. Without it (interactive replies) fall back
+  // to real time. Degrade, never throw: a thrown guard here is uncaught through
+  // the dispatch Promise.all and aborts the entire run for every queued user.
+  const now = options.windowNow ?? new Date();
   if (
     now.getTime() - userInfo.lastEngagementAt.getTime() >
     WHATSAPP_REENGAGEMENT_TIMEOUT_WITH_MARGIN_MS
   ) {
-    throw new Error(
-      `Cannot send message to WH user ${userInfo.chatId} at time ${now.toISOString()}, as his lastEngagement is ${userInfo.lastEngagementAt.toISOString()} (margin is ${String(WHATSAPP_REENGAGEMENT_MARGIN_MINS)}mins)`
+    await logError(
+      "WhatsApp",
+      `Skipped free message to WH user ${userInfo.chatId} at time ${now.toISOString()}, as his lastEngagement is ${userInfo.lastEngagementAt.toISOString()} (margin is ${String(WHATSAPP_REENGAGEMENT_MARGIN_MINS)}mins). User picked up by re-engagement next run/sweep.`
     );
+    return false;
   }
 
   const umamiLogger: UmamiLogger = options.useAsyncUmamiLog

--- a/notifications/alertStringNotifications.ts
+++ b/notifications/alertStringNotifications.ts
@@ -238,7 +238,8 @@ export async function notifyAlertStringUpdates(
       const messageSent = await sendAlertStringUpdate(
         task.userInfo,
         task.updatedRecordsMap,
-        messageAppsOptions
+        messageAppsOptions,
+        now
       );
       if (!messageSent) return;
 
@@ -270,7 +271,9 @@ export async function notifyAlertStringUpdates(
 async function sendAlertStringUpdate(
   userInfo: ExtendedMiniUserInfo,
   updatedRecordMap: Map<string, JORFSearchPublication[]>,
-  messageAppsOptions: ExternalMessageOptions
+  messageAppsOptions: ExternalMessageOptions,
+  // Run-wide clock from the notification path; forwarded to the WH guard.
+  windowNow?: Date
 ): Promise<boolean> {
   if (updatedRecordMap.size === 0) return true;
 
@@ -308,7 +311,8 @@ async function sendAlertStringUpdate(
     ...messageAppsOptions,
     separateMenuMessage: userInfo.messageApp === "WhatsApp",
     useAsyncUmamiLog: true,
-    hasAccount: true
+    hasAccount: true,
+    windowNow
   };
 
   const messageSent = await sendMessage(

--- a/notifications/functionTagNotifications.ts
+++ b/notifications/functionTagNotifications.ts
@@ -311,7 +311,8 @@ export async function notifyFunctionTagsUpdates(
       const messageSent = await sendTagUpdates(
         task.userInfo,
         task.updatedRecordsMap,
-        messageAppsOptions
+        messageAppsOptions,
+        now
       );
       if (!messageSent) return;
 
@@ -344,7 +345,9 @@ export async function notifyFunctionTagsUpdates(
 export async function sendTagUpdates(
   userInfo: ExtendedMiniUserInfo,
   tagMap: Map<FunctionTags, JORFSearchItem[]>,
-  messageAppsOptions: ExternalMessageOptions
+  messageAppsOptions: ExternalMessageOptions,
+  // Run-wide clock from the notification path; forwarded to the WH guard.
+  windowNow?: Date
 ): Promise<boolean> {
   const tagList = [...tagMap.keys()];
 
@@ -405,7 +408,8 @@ export async function sendTagUpdates(
     ...messageAppsOptions,
     separateMenuMessage: userInfo.messageApp === "WhatsApp",
     useAsyncUmamiLog: true,
-    hasAccount: true
+    hasAccount: true,
+    windowNow
   };
 
   const messageSent = await sendMessage(

--- a/notifications/nameNotifications.ts
+++ b/notifications/nameNotifications.ts
@@ -303,7 +303,8 @@ export async function notifyNameMentionUpdates(
     const messageSent = await sendNameMentionUpdates(
       task.userInfo,
       task.updatedRecordsMap,
-      messageAppsOptions
+      messageAppsOptions,
+      now
     );
 
     if (messageSent) {
@@ -324,7 +325,9 @@ export async function notifyNameMentionUpdates(
 export async function sendNameMentionUpdates(
   userInfo: ExtendedMiniUserInfo,
   updatedRecordMap: Map<string, JORFSearchItem[]>,
-  messageAppsOptions: ExternalMessageOptions
+  messageAppsOptions: ExternalMessageOptions,
+  // Run-wide clock from the notification path; forwarded to the WH guard.
+  windowNow?: Date
 ): Promise<boolean> {
   if (updatedRecordMap.size === 0) return true;
 
@@ -370,7 +373,8 @@ export async function sendNameMentionUpdates(
     ...messageAppsOptions,
     separateMenuMessage: userInfo.messageApp === "WhatsApp",
     useAsyncUmamiLog: true,
-    hasAccount: true
+    hasAccount: true,
+    windowNow
   };
 
   const messageSent = await sendMessage(

--- a/notifications/notificationDispatch.ts
+++ b/notifications/notificationDispatch.ts
@@ -7,6 +7,7 @@ import { Types } from "mongoose";
 import pLimit from "p-limit";
 import { MATRIX_API_SENDING_CONCURRENCY } from "../entities/MatrixSession.ts";
 import { ExtendedMiniUserInfo } from "../entities/Session.ts";
+import { logError } from "../utils/debugLogger.ts";
 
 /**
  * Schedules the sendMessage to respect per-app throttling rules.
@@ -66,19 +67,32 @@ export async function dispatchTasksToMessageApps<T, R = JORFSearchItem>(
       appTasks.sort((a, b) => b.recordCount - a.recordCount);
     }
 
+    // Isolate each task: a single send that throws must never reject the
+    // app-level Promise.all and abort the whole run (and every later handler)
+    // for all remaining users. Log and drop only the failing user.
+    const runTask = async (task: NotificationTask<T, R>) => {
+      try {
+        await taskFunction(task);
+      } catch (err) {
+        await logError(
+          messageApp,
+          `Notification task failed for user ${task.userInfo.chatId}`,
+          err
+        );
+      }
+    };
+
     const app_concurrency_limit =
       concurrencyLimitByMessageApp.get(messageApp) ?? 1;
     if (app_concurrency_limit > 1) {
       const limit = pLimit(concurrencyLimitByMessageApp.get(messageApp) ?? 1);
 
       // Wrap each delivery in the limiter
-      await Promise.all(
-        appTasks.map((task) => limit(() => taskFunction(task)))
-      );
+      await Promise.all(appTasks.map((task) => limit(() => runTask(task))));
     } else {
       // if appLimit is 1, just run the taskFunction directly
       for (const task of appTasks) {
-        await taskFunction(task);
+        await runTask(task);
       }
     }
   });

--- a/notifications/organisationNotifications.ts
+++ b/notifications/organisationNotifications.ts
@@ -320,7 +320,8 @@ export async function notifyOrganisationsUpdates(
         task.userInfo,
         task.updatedRecordsMap,
         orgNameById,
-        messageAppsOptions
+        messageAppsOptions,
+        now
       );
       if (!messageSent) return;
 
@@ -356,7 +357,9 @@ export async function sendOrganisationUpdate(
   userInfo: ExtendedMiniUserInfo,
   organisationsUpdateRecordsMap: Map<WikidataId, JORFSearchItem[]>,
   orgNameById: Map<WikidataId, string>,
-  messageAppsOptions: ExternalMessageOptions
+  messageAppsOptions: ExternalMessageOptions,
+  // Run-wide clock from the notification path; forwarded to the WH guard.
+  windowNow?: Date
 ): Promise<boolean> {
   if (organisationsUpdateRecordsMap.size === 0) return true;
 
@@ -423,7 +426,8 @@ export async function sendOrganisationUpdate(
     ...messageAppsOptions,
     separateMenuMessage: userInfo.messageApp === "WhatsApp",
     useAsyncUmamiLog: true,
-    hasAccount: true
+    hasAccount: true,
+    windowNow
   };
 
   const messageSent = await sendMessage(

--- a/notifications/peopleNotifications.ts
+++ b/notifications/peopleNotifications.ts
@@ -328,7 +328,8 @@ export async function notifyPeopleUpdates(
     const messageSent = await sendPeopleUpdate(
       task.userInfo,
       task.updatedRecordsMap,
-      messageAppsOptions
+      messageAppsOptions,
+      now
     );
     if (!messageSent) return;
 
@@ -365,7 +366,10 @@ export async function notifyPeopleUpdates(
 export async function sendPeopleUpdate(
   userInfo: ExtendedMiniUserInfo,
   updatedRecordMap: Map<string, JORFSearchItem[]>,
-  messageAppsOptions: ExternalMessageOptions
+  messageAppsOptions: ExternalMessageOptions,
+  // Run-wide clock from the notification path; forwarded to the WH guard so it
+  // agrees with the routing decision. Undefined elsewhere → guard uses new Date().
+  windowNow?: Date
 ) {
   if (updatedRecordMap.size === 0) return true;
 
@@ -414,7 +418,8 @@ export async function sendPeopleUpdate(
     ...messageAppsOptions,
     separateMenuMessage: userInfo.messageApp === "WhatsApp",
     useAsyncUmamiLog: true,
-    hasAccount: true
+    hasAccount: true,
+    windowNow
   };
 
   const messageSent = await sendMessage(

--- a/tests/10.notificationDispatch.test.ts
+++ b/tests/10.notificationDispatch.test.ts
@@ -78,6 +78,31 @@ describe("dispatchTasksToMessageApps — WhatsApp edge-first ordering", () => {
   });
 });
 
+describe("dispatchTasksToMessageApps — a failing task can't abort the run", () => {
+  it("logs and skips a throwing task, still processing the rest", async () => {
+    const tasks = [
+      makeTask("wh-edge", "WhatsApp", DAY_MS, 1), // processed first (edge), throws
+      makeTask("wh-mid", "WhatsApp", 12 * 60 * 60 * 1000, 1),
+      makeTask("wh-fresh", "WhatsApp", 1 * 60 * 60 * 1000, 1)
+    ];
+
+    const processed: string[] = [];
+    // No try/catch here: if the dispatcher re-threw, this await would reject and
+    // the test would fail — which is exactly the regression we're guarding.
+    await dispatchTasksToMessageApps<string>(tasks, async (task) => {
+      if (task.userInfo.chatId === "wh-edge") {
+        await Promise.resolve();
+        throw new Error("send blew up");
+      }
+      processed.push(task.userInfo.chatId);
+      await Promise.resolve();
+    });
+
+    // The throwing user is dropped; every sibling still got processed.
+    expect(processed).toEqual(["wh-mid", "wh-fresh"]);
+  });
+});
+
 describe("dispatchTasksToMessageApps — non-WhatsApp ordering unchanged", () => {
   it("orders Telegram users by record count (largest first), ignoring window edge", async () => {
     const tasks = [

--- a/tests/13.whatsappSendGuard.test.ts
+++ b/tests/13.whatsappSendGuard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+
+// WhatsAppSession reads WHATSAPP_PHONE_ID at module load, so set it before the
+// import is hoisted (vi.hoisted runs first). Without it the post-guard send path
+// would throw "WHATSAPP_PHONE_ID is not set" and we couldn't reach the API stub.
+vi.hoisted(() => {
+  process.env.WHATSAPP_PHONE_ID = "TEST_PHONE_ID";
+});
+
+// Keep umami/logError side-effects inert; the guard logs on the degrade path.
+vi.mock("../utils/umami.ts", () => ({
+  default: { log: vi.fn(), logAsync: vi.fn() }
+}));
+
+import { sendWhatsAppMessage } from "../entities/WhatsAppSession.ts";
+import type { ExtendedMiniUserInfo } from "../entities/Session.ts";
+import type { WhatsAppAPI } from "whatsapp-api-js/middleware/express";
+
+const MIN_MS = 60 * 1000;
+const HOUR_MS = 60 * MIN_MS;
+
+const waUser = (lastEngagementAt: Date): ExtendedMiniUserInfo => ({
+  messageApp: "WhatsApp",
+  chatId: "guard-" + Math.random().toString(36).slice(2),
+  status: "active",
+  hasAccount: true,
+  waitingReengagement: false,
+  lastEngagementAt
+});
+
+describe("sendWhatsAppMessage — re-engagement guard", () => {
+  it("degrades (returns false, no throw, no API call) when expired and no windowNow", async () => {
+    const sendMessage = vi.fn();
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+
+    // 24h ago by wall clock -> past the 23h55m cutoff. No windowNow -> real time.
+    const userInfo = waUser(new Date(Date.now() - 24 * HOUR_MS));
+
+    // Must NOT throw: a thrown guard is uncaught through the dispatch Promise.all
+    // and aborts the whole run. It must return false instead.
+    const res = await sendWhatsAppMessage(api, userInfo, "hi", {
+      hasAccount: true
+    });
+
+    expect(res).toBe(false);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("honors windowNow: a user in-window per windowNow still sends, even if wall-clock drifted past the cutoff", async () => {
+    // Reject the actual API call so we stop right after the guard, before
+    // cooldowns / DB writes — we only need to prove the guard let us through.
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("stop after guard"));
+    const api = { sendMessage } as unknown as WhatsAppAPI;
+
+    // Wall clock: 23h58m ago -> would be rejected by new Date() (past 23h55m).
+    const lastEngagementAt = new Date(Date.now() - (24 * 60 - 2) * MIN_MS);
+    // windowNow: 23h after engagement -> comfortably in window.
+    const windowNow = new Date(lastEngagementAt.getTime() + 23 * HOUR_MS);
+
+    const res = await sendWhatsAppMessage(api, waUser(lastEngagementAt), "hi", {
+      hasAccount: true,
+      windowNow
+    });
+
+    // Guard passed (used windowNow, not wall clock): the API was reached.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // The injected API error is swallowed -> false, never thrown.
+    expect(res).toBe(false);
+  });
+});


### PR DESCRIPTION
Sync DanyPM/joel main with upstream fabrahaingo/joel main after merging #305 (fix(whatsapp): make re-engagement send guard non-fatal and clock-consistent). Fast-forward only; no DanyPM-specific changes.